### PR TITLE
R2: five-level deduplication pipeline

### DIFF
--- a/docs/PROJECT-MAP.md
+++ b/docs/PROJECT-MAP.md
@@ -166,7 +166,13 @@ for which regions are done.
 - **What it is:** `DbConnectionFactory` (opens an `NpgsqlConnection` from a
   shared `NpgsqlDataSource`), `DapperConfig.Initialize()` (one-time Dapper
   type-handler + dialect registration), and four custom `SqlMapper.TypeHandler`
-  implementations (Jsonb, GuidArray, FloatArray, Enum).
+  implementations (Jsonb, GuidArray, FloatArray, Enum). `DapperConfig`
+  registers one `JsonbTypeHandler<T>` instance per JSONB-backed .NET type and
+  one `EnumTypeHandler<T>` per string-backed native enum column; P1-1 (2026-
+  07-21) added four new `EnumTypeHandler` registrations (`SourceTier`,
+  `TrustState`, `ExtractionMethod`, `ChangeReason`) and one new
+  `JsonbTypeHandler<List<SourceTier>>` registration for
+  `domain_trust_policy`'s `auto_accept_tiers`/`flag_for_review_tiers` columns.
 - **Responsibility:** Owns how every repository gets a PostgreSQL connection
   and how Dapper maps PostgreSQL-specific column types (`jsonb`, `uuid[]`,
   `real[]`, native enums) to/from .NET types. The pgvector `vector` type
@@ -238,27 +244,38 @@ for which regions are done.
   `Extraction/SemanticChunkerAdapter.cs`.
 
 ## Repositories  [KEEP]
-- **What it is:** Nine Dapper-based repository implementations — one per
+- **What it is:** Twelve Dapper-based repository implementations — one per
   `Deke.Core` repository interface: `FactRepository`, `SourceRepository`,
   `TermRepository`, `PatternRepository`, `FactRelationRepository`,
   `LearningLogRepository`, `InteractionLogRepository`,
-  `FederationPeerRepository`, `AdvisoryInteractionRepository`.
+  `FederationPeerRepository`, `AdvisoryInteractionRepository`, and — added by
+  P1-1 (2026-07-21) — `FactProvenanceRepository`, `FactVersionRepository`,
+  `DomainTrustPolicyRepository`.
 - **Responsibility:** Owns all SQL for CRUD + the pgvector similarity search
   (`FactRepository.SearchAsync`, `1 - (embedding <=> @vector::vector)`).
   Every repository follows the same shape: constructor-injected
-  `DbConnectionFactory`, raw SQL strings, no query builder.
+  `DbConnectionFactory`, raw SQL strings, no query builder. Two of the three
+  P1-1 repositories deviate slightly: `FactVersionRepository` adds
+  `GetAsOfAsync` (a point-in-time query answering "what did we believe on
+  date X?"), and `DomainTrustPolicyRepository` exposes `UpsertAsync` instead
+  of separate insert/update, since `domain_trust_policy` is keyed by
+  `domain` rather than an auto-generated id.
 - **Key dependencies:** →Data Access & Type Handlers (`DbConnectionFactory`,
   registered type handlers).
 - **Naming issues:** none.
 - **Design smells:** none.
 - **Confidence:** HIGH (`FactRepository`, `FederationPeerRepository` read in
-  full; remaining seven inferred from consistent naming, 1:1 interface match
-  confirmed in `ServiceCollectionExtensions.cs`, and the two read in full
-  sharing an identical structural pattern — not independently read line by
-  line).
+  full; remaining seven pre-P1-1 repositories inferred from consistent
+  naming, 1:1 interface match confirmed in `ServiceCollectionExtensions.cs`,
+  and the two read in full sharing an identical structural pattern — not
+  independently read line by line; the three P1-1 repositories and their
+  interfaces read in full).
 - **Sources read:** `Repositories/FactRepository.cs` (full),
   `FederationPeerRepository.cs` (partial); interface list cross-checked
-  against `ServiceCollectionExtensions.cs:32-38,75`.
+  against `ServiceCollectionExtensions.cs:32-38,75`;
+  `Repositories/FactProvenanceRepository.cs`,
+  `FactVersionRepository.cs`, `DomainTrustPolicyRepository.cs`, and their
+  matching `Deke.Core/Interfaces/I*.cs` files (all full, P1-1 addition).
 
 ## Trust  [KEEP]
 - **What it is:** `TrustScoringService`, the sole `ITrustScoringService`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,15 +42,14 @@ ingestion, interaction logging) are done.
 
 ```
 NOW (no unmet dependencies, parallelizable)
-  P1-1  trust & provenance schema      ← first priority
   RES-1 vectorless RAG research        ← parallel, read-only
   HYG-1 doc-sync sweep
   HYG-2 missing REST endpoints         ← done 2026-07-14
   HYG-3 Api/Mcp test coverage
 
-NEXT (dependencies above)
-  P1-1 ──→ R2   five-level deduplication
-  P1-1 ──→ P1-2 quality pipeline
+NEXT (dependencies above; P1-1 done 2026-07-21, so R2/P1-2 are now available)
+  R2    five-level deduplication       ← unblocked, depends only on P1-1
+  P1-2  quality pipeline               ← unblocked, depends only on P1-1
   RES-1 ─→ (spawned design packet: hybrid retrieval)
   R4   cross-encoder re-ranking        (R1 done; consult RES-1 findings)
   R5   PDF + Markdown ingestion        (R1 done)
@@ -69,17 +68,19 @@ TRIGGER-GATED (sized only when the trigger fires)
 
 ## Sized Packets — Ready Now
 
-### P1-1: Trust and provenance schema — first priority
+### P1-1: Trust and provenance schema — done (2026-07-21)
 
 - **Goal:** Implement the planned provenance/trust schema (planned tables plus
   source/fact column additions, [specification.md](architecture/specification.md)
-  Planned Tables section) before more data accumulates.
+  Planned Tables section — now folded into Current Tables, see Status below)
+  before more data accumulates.
 - **Why first:** the 2026-03 decision log calls P1-1 the critical path —
   schema changes after data are expensive, and bootstrap ingestion has
   already run.
 - **Depends on:** nothing. **Unblocks:** R2, P1-2.
-- **Context budget:** specification.md Planned Tables / Planned Source & Fact
-  Additions; `init.sql`; PROJECT-MAP: Data Access & Type Handlers,
+- **Context budget (as originally scoped):** specification.md Planned Tables /
+  Planned Source & Fact Additions (sections no longer exist post-completion —
+  see specification.md Current Tables); `init.sql`; PROJECT-MAP: Data Access & Type Handlers,
   Repositories, Trust.
 - **Tool budget:** serena, roslyn, postgres-mcp, dotnet SDK, git.
 - **Tier:** strongest available, extended thinking (schema decisions are
@@ -87,6 +88,21 @@ TRIGGER-GATED (sized only when the trigger fires)
 - **Done when:** `init.sql` and models/repositories updated and applied;
   build + tests pass; specification.md's planned-schema sections moved to
   current (via doc-maintainer).
+- **Status:** Done 2026-07-21. Shipped with a reconciled scope, not the
+  literal 2026-03 plan text: the plan predated the 2026-04 trust-framework
+  simplification and still listed `confidence_score`/`credibility_score` as
+  new columns duplicating the already-shipped `confidence`/`credibility`.
+  Presented to Mikael via AskUserQuestion; he chose to reconcile (see
+  [decisions.md](architecture/decisions.md) 2026-07-21 entry). Delivered: 3
+  new tables (`fact_provenance`, `fact_version`, `domain_trust_policy`); new
+  columns `source_tier`/`independence_fingerprint`/`last_verified_at` on
+  `sources` and `corroboration_count`/`last_verified_at`/
+  `contradiction_flag`/`trust_state` on `facts`; matching C# models, 3 new
+  repository interfaces + Dapper implementations, and DI/type-handler
+  registrations. Schema-only — no corroboration-counting, contradiction-
+  detection, or trust_state transition logic (that's P1-2). Verified: build
+  green, 80/80 tests passing, live-applied to the running `deke-postgres`
+  container. Unblocks R2 and P1-2, now moved to the NEXT lane.
 
 ### RES-1: Vectorless RAG and hybrid retrieval research (ADR-0010)
 
@@ -335,3 +351,4 @@ beats speculative sizing.
 | 2026-07-14 | Overhaul design packets | `Llm/` retired onto `IChatClient` (ADR-0007); API-key fail-fast (ADR-0008); fact-only domains visible over MCP (ADR-0009); glossary ENFORCED via CI lint; MVP recognized as delivered in full. |
 | 2026-07-14 | Roadmap rebuilt | This file: all planned work re-expressed as sized packets in a DAG (overhaul packet OP-011, exit criterion 7). |
 | 2026-07-14 | Overhaul dissolved | All 8 exit criteria passed (OP-012). `overhaul/` archived in place — kept for history, excluded from agent context budgets. Repo tagged `overhaul-complete` (overhaul packet OP-013). |
+| 2026-07-21 | P1-1 done | Trust and provenance schema, reconciled scope (see [decisions.md](architecture/decisions.md) 2026-07-21 entry): 3 new tables (`fact_provenance`, `fact_version`, `domain_trust_policy`), new trust columns on `sources`/`facts`, matching models/repositories/DI. Schema only — algorithms deferred to P1-2. Build green, 80/80 tests passing. R2 and P1-2 unblocked. |

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -87,6 +87,35 @@ Decisions made while validating the advisory pipeline against a live Anthropic c
 |------|----------|-----------|
 | 2026-07-07 | Pin `Microsoft.Extensions.AI` and `Microsoft.Extensions.AI.Abstractions` to 10.3.0, and `OllamaSharp` to 5.3.0, rather than the latest of each | `Anthropic.SDK` 5.10.0 (the latest release and the only version implementing `IChatClient`) was compiled against `Microsoft.Extensions.AI.Abstractions` 10.3.0 and calls `HostedMcpServerTool.AuthorizationToken`, a member `Microsoft.Extensions.AI` removed by 10.4.1. Running against 10.7.0 threw a runtime `MissingMethodException` on every model call -- invisible to unit tests (fake `IChatClient`), caught only by a live Anthropic call. `OllamaSharp` 5.4.x floors at `Microsoft.Extensions.AI` 10.4.1 (incompatible with the required 10.3.0), so it was downgraded to 5.3.0, whose floor is <= 10.3.0. Net: `Anthropic.SDK` 5.10.0, `OllamaSharp` 5.3.0, and `Microsoft.Extensions.AI` 10.3.0 coexist. Revisit when a newer `Anthropic.SDK` targets `Microsoft.Extensions.AI` >= 10.4. |
 
+### 2026-07-21 P1-1 Trust and Provenance Schema Reconciliation
+
+P1-1's original 2026-03 plan (specification.md's former "Planned Tables (P1-1)" /
+"Planned Source Table Additions" / "Planned Fact Table Additions" sections) predates
+the 2026-04 Product Checkpoint's "Simplify trust framework to source credibility +
+fact confidence + temporal validity" decision (above). By 2026-07-21 that plan had
+drifted: it still listed `confidence_score` and `credibility_score` as new columns,
+and re-listed `valid_from`/`valid_until` as "planned" -- all four already shipped
+under the 2026-04 simplification (`confidence` on facts, `credibility` on sources,
+`valid_from`/`valid_until` on facts, all live in `init.sql`/`Fact.cs`/`Source.cs`
+before this work started). Implementing the literal 2026-03 text would have
+duplicated live columns under new names.
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-07-21 | Reconcile P1-1 to skip columns that duplicate already-shipped trust fields | Presented to Mikael via AskUserQuestion: implement the plan as originally written (re-adding `confidence_score`/`credibility_score` alongside the existing `confidence`/`credibility`), or reconcile (implement only genuinely new schema, treating existing `confidence`/`credibility`/`valid_from`/`valid_until` as already satisfying their `_score`-suffixed planned counterparts). Mikael chose reconcile. |
+| 2026-07-21 | Ship 3 new tables (`fact_provenance`, `fact_version`, `domain_trust_policy`) plus only the genuinely new source/fact columns | New on `sources`: `source_tier`, `independence_fingerprint`, `last_verified_at` (`credibility_score` skipped -- duplicate of `credibility`). New on `facts`: `corroboration_count`, `last_verified_at`, `contradiction_flag`, `trust_state` (`confidence_score` skipped -- duplicate of `confidence`; `valid_from`/`valid_until` skipped as "new" since both already existed and were simply undocumented in specification.md's Current Tables section until this reconciliation). |
+| 2026-07-21 | Keep P1-1 schema-only; defer corroboration-counting, contradiction-detection, and trust_state transition logic to P1-2 | The new columns and tables (`corroboration_count`, `contradiction_flag`, `trust_state`, `domain_trust_policy`'s policy fields) are storage and configuration only in this packet -- no code populates or transitions them yet. This matches [ROADMAP.md](../ROADMAP.md)'s P1-1/P1-2 split: P1-1 is schema, P1-2 is the quality-pipeline logic that reads and writes it. |
+
+Verified: build green, 80/80 tests passing, schema live-applied to the running
+`deke-postgres` container. See [ROADMAP.md](../ROADMAP.md) P1-1 for closure status
+and [PROJECT-MAP.md](../PROJECT-MAP.md) Repositories / Data Access & Type Handlers
+for the new repository and type-handler entries.
+
+**Separately discovered, not part of this reconciliation:** the live `deke-postgres`
+container (running ~2 weeks at time of discovery) is missing the `interaction_logs`
+table that `init.sql` has always defined -- pre-existing schema drift, unrelated to
+P1-1, predating this work. Not fixed here; flagged for follow-up.
+
 ---
 
 ## Guardrails and Risk Analysis

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -116,6 +116,11 @@ container (running ~2 weeks at time of discovery) is missing the `interaction_lo
 table that `init.sql` has always defined -- pre-existing schema drift, unrelated to
 P1-1, predating this work. Not fixed here; flagged for follow-up.
 
+**Follow-up (2026-07-21):** Closed. `CREATE TABLE interaction_logs` and its two
+indexes (`idx_interaction_logs_created`, `idx_interaction_logs_domain`) were applied
+to the live container from `init.sql`'s existing definition -- no code or `init.sql`
+changes needed. All 12 `init.sql` tables now present, verified via `\dt`.
+
 ---
 
 ## Guardrails and Risk Analysis

--- a/docs/architecture/specification.md
+++ b/docs/architecture/specification.md
@@ -93,6 +93,9 @@ Where facts come from. Each source is a monitorable endpoint (RSS feed, web page
 | is_active | BOOLEAN | Whether monitoring is enabled |
 | created_at | TIMESTAMPTZ | Row creation time |
 | metadata | JSONB | Extensible key-value store |
+| source_tier | VARCHAR(20) | Trust tier: Primary, Secondary, Aggregated, Unverified (default Unverified) |
+| independence_fingerprint | VARCHAR(64) | Hash of publisher identity, used to prevent single-source amplification during corroboration |
+| last_verified_at | TIMESTAMPTZ | Last confirmation source is still authoritative |
 
 #### facts
 
@@ -113,6 +116,12 @@ The atomic unit of knowledge. A single claim with provenance metadata.
 | updated_at | TIMESTAMPTZ | Last modification |
 | is_outdated | BOOLEAN | Soft-delete flag |
 | outdated_reason | VARCHAR(200) | Why marked outdated |
+| valid_from | TIMESTAMPTZ | When the fact became true |
+| valid_until | TIMESTAMPTZ | When the fact ceased to be true |
+| corroboration_count | INT | Independent sources asserting an equivalent claim (default 0) |
+| last_verified_at | TIMESTAMPTZ | Last confirmation against source |
+| contradiction_flag | BOOLEAN | Another fact with opposing polarity exists (default FALSE) |
+| trust_state | VARCHAR(20) | Unscored, Accepted, Flagged, Contested, Rejected (default Unscored) |
 
 Indexes: IVFFlat on embedding (cosine ops, lists=100), domain, source_id, created_at DESC, composite (domain, is_outdated).
 
@@ -199,19 +208,20 @@ Known DEKE instances for cross-instance queries.
 | is_healthy | BOOLEAN | Current health status |
 | created_at | TIMESTAMPTZ | When peer was first discovered |
 
-### Planned Tables (P1-1)
-
 #### fact_provenance
 
 One-to-many link between facts and the sources that assert them. Supports corroboration tracking without fact duplication.
 
 | Column | Type | Description |
 |--------|------|-------------|
+| id | UUID PK | Auto-generated |
 | fact_id | UUID FK | Reference to fact |
 | source_id | UUID FK | Reference to source |
 | extracted_at | TIMESTAMPTZ | When this assertion was recorded |
-| extraction_method | VARCHAR(30) | rss_harvest, web_harvest, manual_api, llm_extract |
+| extraction_method | VARCHAR(30) | RssHarvest, WebHarvest, ManualApi, LlmExtract |
 | extraction_confidence | REAL | Confidence of the extraction process itself |
+
+Unique constraint on (fact_id, source_id).
 
 #### fact_version
 
@@ -219,11 +229,12 @@ Immutable change history. Enables "what did we believe on date X?" queries.
 
 | Column | Type | Description |
 |--------|------|-------------|
+| id | UUID PK | Auto-generated |
 | fact_id | UUID FK | Reference to fact |
 | content_snapshot | TEXT | Fact text at this version |
 | embedding_snapshot | vector(384) | Embedding at this version |
 | changed_at | TIMESTAMPTZ | When change occurred |
-| change_reason | VARCHAR(30) | source_update, manual_correction, merge, contradiction_resolution |
+| change_reason | VARCHAR(30) | SourceUpdate, ManualCorrection, Merge, ContradictionResolution |
 
 #### domain_trust_policy
 
@@ -238,27 +249,6 @@ Per-domain configuration governing how strictly provenance is enforced.
 | flag_for_review_tiers | JSONB | Source tiers that enter review queue |
 | temporal_validity_required | BOOLEAN | Facts without valid_from are flagged |
 | min_confidence_score | REAL | Facts below threshold enter review queue |
-
-### Planned Source Table Additions
-
-| Column | Type | Description |
-|--------|------|-------------|
-| credibility_score | REAL | 0.0-1.0, separate from fact confidence |
-| source_tier | VARCHAR(20) | primary, secondary, aggregated, unverified |
-| independence_fingerprint | VARCHAR(64) | Hash of publisher identity for corroboration independence |
-| last_verified_at | TIMESTAMPTZ | Last confirmation source is still authoritative |
-
-### Planned Fact Table Additions
-
-| Column | Type | Description |
-|--------|------|-------------|
-| confidence_score | REAL | 0.0-1.0, assessed at extraction time |
-| corroboration_count | INT | Independent sources asserting equivalent claim |
-| valid_from | TIMESTAMPTZ | When the fact became true |
-| valid_until | TIMESTAMPTZ | When the fact ceased to be true |
-| last_verified_at | TIMESTAMPTZ | Last confirmation against source |
-| contradiction_flag | BOOLEAN | Another fact with opposing polarity exists |
-| trust_state | VARCHAR(20) | unscored, accepted, flagged, contested, rejected |
 
 ---
 
@@ -280,12 +270,18 @@ public class Fact
     public float Confidence { get; set; } = 1.0f;
     public Guid? SourceId { get; set; }
     public List<Guid> RelatedFactIds { get; set; } = [];
-    public JsonElement Entities { get; set; }
-    public Dictionary<string, JsonElement> Metadata { get; set; } = new();
+    public List<ExtractedEntity> Entities { get; set; } = [];
+    public Dictionary<string, JsonElement> Metadata { get; set; } = [];
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset? UpdatedAt { get; set; }
     public bool IsOutdated { get; set; }
     public string? OutdatedReason { get; set; }
+    public DateTimeOffset? ValidFrom { get; set; }
+    public DateTimeOffset? ValidUntil { get; set; }
+    public int CorroborationCount { get; set; }
+    public DateTimeOffset? LastVerifiedAt { get; set; }
+    public bool ContradictionFlag { get; set; }
+    public TrustState TrustState { get; set; } = TrustState.Unscored;
 }
 ```
 
@@ -308,9 +304,24 @@ public class Source
     public float Credibility { get; set; } = 0.5f;
     public bool IsActive { get; set; } = true;
     public DateTimeOffset CreatedAt { get; set; }
-    public Dictionary<string, JsonElement> Metadata { get; set; } = new();
+    public Dictionary<string, JsonElement> Metadata { get; set; } = [];
+    public SourceTier SourceTier { get; set; } = SourceTier.Unverified;
+    public string? IndependenceFingerprint { get; set; }
+    public DateTimeOffset? LastVerifiedAt { get; set; }
 }
 ```
+
+### FactProvenance
+
+One-to-many link between a fact and the sources that assert it. Maps to the `fact_provenance` table. Supports corroboration tracking without fact duplication.
+
+### FactVersion
+
+Immutable change-history snapshot of a fact. Maps to the `fact_version` table. `IFactVersionRepository.GetAsOfAsync` answers "what did we believe on date X?" queries.
+
+### DomainTrustPolicy
+
+Per-domain configuration governing how strictly provenance is enforced. Maps to the `domain_trust_policy` table, keyed by `domain` (no surrogate id) -- `IDomainTrustPolicyRepository` exposes `UpsertAsync` rather than separate insert/update.
 
 ### FederationPeer
 

--- a/init.sql
+++ b/init.sql
@@ -27,6 +27,9 @@ CREATE TABLE sources (
     is_active BOOLEAN NOT NULL DEFAULT TRUE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     metadata JSONB DEFAULT '{}',
+    source_tier VARCHAR(20) NOT NULL DEFAULT 'Unverified',
+    independence_fingerprint VARCHAR(64),
+    last_verified_at TIMESTAMPTZ,
     CONSTRAINT sources_url_unique UNIQUE (url)
 );
 
@@ -50,7 +53,11 @@ CREATE TABLE facts (
     is_outdated BOOLEAN NOT NULL DEFAULT FALSE,
     outdated_reason VARCHAR(200),
     valid_from TIMESTAMPTZ,
-    valid_until TIMESTAMPTZ
+    valid_until TIMESTAMPTZ,
+    corroboration_count INT NOT NULL DEFAULT 0,
+    last_verified_at TIMESTAMPTZ,
+    contradiction_flag BOOLEAN NOT NULL DEFAULT FALSE,
+    trust_state VARCHAR(20) NOT NULL DEFAULT 'Unscored'
 );
 
 CREATE INDEX idx_facts_embedding ON facts
@@ -175,3 +182,40 @@ CREATE TABLE federation_peers (
 );
 
 CREATE INDEX idx_federation_peers_healthy ON federation_peers(is_healthy) WHERE is_healthy = TRUE;
+
+-- Fact provenance: one-to-many link between facts and the sources that assert them
+CREATE TABLE fact_provenance (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    fact_id UUID NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
+    source_id UUID NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    extracted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    extraction_method VARCHAR(30) NOT NULL,
+    extraction_confidence REAL NOT NULL DEFAULT 1.0,
+    CONSTRAINT fact_provenance_unique UNIQUE (fact_id, source_id)
+);
+
+CREATE INDEX idx_fact_provenance_fact ON fact_provenance(fact_id);
+CREATE INDEX idx_fact_provenance_source ON fact_provenance(source_id);
+
+-- Fact version: immutable change history, "what did we believe on date X"
+CREATE TABLE fact_version (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    fact_id UUID NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
+    content_snapshot TEXT NOT NULL,
+    embedding_snapshot vector(384),
+    changed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    change_reason VARCHAR(30) NOT NULL
+);
+
+CREATE INDEX idx_fact_version_fact ON fact_version(fact_id, changed_at DESC);
+
+-- Domain trust policy: per-domain configuration governing provenance strictness
+CREATE TABLE domain_trust_policy (
+    domain VARCHAR(100) PRIMARY KEY,
+    require_primary_source BOOLEAN NOT NULL DEFAULT FALSE,
+    min_corroboration INT NOT NULL DEFAULT 0,
+    auto_accept_tiers JSONB NOT NULL DEFAULT '[]',
+    flag_for_review_tiers JSONB NOT NULL DEFAULT '[]',
+    temporal_validity_required BOOLEAN NOT NULL DEFAULT FALSE,
+    min_confidence_score REAL NOT NULL DEFAULT 0.0
+);

--- a/init.sql
+++ b/init.sql
@@ -57,7 +57,12 @@ CREATE TABLE facts (
     corroboration_count INT NOT NULL DEFAULT 0,
     last_verified_at TIMESTAMPTZ,
     contradiction_flag BOOLEAN NOT NULL DEFAULT FALSE,
-    trust_state VARCHAR(20) NOT NULL DEFAULT 'Unscored'
+    trust_state VARCHAR(20) NOT NULL DEFAULT 'Unscored',
+    -- R2 deduplication (levels 1-5)
+    content_hash VARCHAR(64),
+    normalized_hash VARCHAR(64),
+    similarity_hash BIGINT,
+    duplicate_of UUID REFERENCES facts(id) ON DELETE SET NULL
 );
 
 CREATE INDEX idx_facts_embedding ON facts
@@ -67,6 +72,12 @@ CREATE INDEX idx_facts_domain ON facts(domain);
 CREATE INDEX idx_facts_source ON facts(source_id);
 CREATE INDEX idx_facts_created ON facts(created_at DESC);
 CREATE INDEX idx_facts_active ON facts(domain, is_outdated) WHERE is_outdated = FALSE;
+
+-- R2 dedup: exact-match lookup (levels 2-3) and per-domain uniqueness guard
+CREATE INDEX idx_facts_content_hash ON facts(content_hash);
+CREATE UNIQUE INDEX idx_facts_domain_normhash ON facts(domain, normalized_hash);
+-- R2 dedup: async level-4 candidate scan (facts without a similarity hash yet)
+CREATE INDEX idx_facts_pending_simhash ON facts(id) WHERE similarity_hash IS NULL;
 
 -- Terms: Domain-specific terminology
 CREATE TABLE terms (

--- a/scripts/migrations/2026-07-21-r2-dedup.sql
+++ b/scripts/migrations/2026-07-21-r2-dedup.sql
@@ -1,0 +1,26 @@
+-- R2 five-level deduplication schema.
+-- Idempotent upgrade for the live container (init.sql covers fresh installs).
+-- Additive only: nullable columns + indexes. Safe to re-run.
+
+ALTER TABLE facts ADD COLUMN IF NOT EXISTS content_hash VARCHAR(64);
+ALTER TABLE facts ADD COLUMN IF NOT EXISTS normalized_hash VARCHAR(64);
+ALTER TABLE facts ADD COLUMN IF NOT EXISTS similarity_hash BIGINT;
+ALTER TABLE facts ADD COLUMN IF NOT EXISTS duplicate_of UUID REFERENCES facts(id) ON DELETE SET NULL;
+
+-- Exact-match lookup (levels 2-3) and per-domain uniqueness guard.
+-- NULL normalized_hash rows (legacy / pre-backfill) are exempt: Postgres
+-- treats NULLs as distinct, so multiple NULLs coexist under the unique index.
+CREATE INDEX IF NOT EXISTS idx_facts_content_hash ON facts(content_hash);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_facts_domain_normhash ON facts(domain, normalized_hash);
+
+-- Async level-4 candidate scan (facts without a similarity hash yet).
+CREATE INDEX IF NOT EXISTS idx_facts_pending_simhash ON facts(id) WHERE similarity_hash IS NULL;
+
+-- rollback:
+--   DROP INDEX IF EXISTS idx_facts_pending_simhash;
+--   DROP INDEX IF EXISTS idx_facts_domain_normhash;
+--   DROP INDEX IF EXISTS idx_facts_content_hash;
+--   ALTER TABLE facts DROP COLUMN IF EXISTS duplicate_of;
+--   ALTER TABLE facts DROP COLUMN IF EXISTS similarity_hash;
+--   ALTER TABLE facts DROP COLUMN IF EXISTS normalized_hash;
+--   ALTER TABLE facts DROP COLUMN IF EXISTS content_hash;

--- a/src/Deke.Api/Endpoints/FactEndpoints.cs
+++ b/src/Deke.Api/Endpoints/FactEndpoints.cs
@@ -67,7 +67,7 @@ public static class FactEndpoints
 
     private static async Task<IResult> AddFact(
         AddFactRequest request,
-        IFactRepository factRepo,
+        IDeduplicationService dedup,
         IEmbeddingService embeddings,
         CancellationToken ct)
     {
@@ -86,8 +86,8 @@ public static class FactEndpoints
             Metadata = request.Metadata ?? []
         };
 
-        var id = await factRepo.AddAsync(fact, ct);
-        return Results.Created($"/api/facts/{id}", new { id });
+        var result = await dedup.IngestAsync(fact, ExtractionMethod.ManualApi, ct);
+        return Results.Created($"/api/facts/{result.FactId}", new { id = result.FactId, duplicate = result.WasDuplicate });
     }
 
     internal static async Task<IResult> UpdateFact(

--- a/src/Deke.Api/Program.cs
+++ b/src/Deke.Api/Program.cs
@@ -27,6 +27,7 @@ if (string.IsNullOrEmpty(builder.Configuration["ApiKey"]))
 
 builder.Services.AddDekeInfrastructure(connectionString);
 builder.Services.AddDekeEmbeddings(builder.Configuration);
+builder.Services.AddDekeDedup(builder.Configuration);
 builder.Services.AddDekeFederation(builder.Configuration);
 
 // Authentication

--- a/src/Deke.Core/Interfaces/IContentHasher.cs
+++ b/src/Deke.Core/Interfaces/IContentHasher.cs
@@ -1,0 +1,16 @@
+﻿namespace Deke.Core.Interfaces;
+
+/// <summary>
+/// Computes deterministic exact-match hashes for deduplication levels 2 and 3.
+/// </summary>
+public interface IContentHasher
+{
+    /// <summary>SHA-256 hex of the raw content (level 2, exact match).</summary>
+    string ContentHash(string content);
+
+    /// <summary>
+    /// SHA-256 hex of the normalized content (level 3): whitespace collapsed,
+    /// lowercased, punctuation stripped, Unicode NFKC-normalized.
+    /// </summary>
+    string NormalizedHash(string content);
+}

--- a/src/Deke.Core/Interfaces/IDeduplicationService.cs
+++ b/src/Deke.Core/Interfaces/IDeduplicationService.cs
@@ -1,0 +1,22 @@
+﻿using Deke.Core.Models;
+
+namespace Deke.Core.Interfaces;
+
+/// <summary>
+/// Shared ingest gateway. All fact inserts route through this so that
+/// synchronous dedup levels 1-3 run and a provenance link is recorded on
+/// every insert (first sighting or duplicate).
+/// </summary>
+public interface IDeduplicationService
+{
+    /// <summary>
+    /// Runs synchronous dedup levels 1-3 for a fully-built fact (embedding set).
+    /// On a duplicate the incoming fact is discarded, the canonical fact is
+    /// corroborated, and a provenance link is written; otherwise the fact is
+    /// inserted with its hashes and a first-sighting provenance row.
+    /// </summary>
+    Task<DedupResult> IngestAsync(Fact fact, ExtractionMethod method, CancellationToken ct = default);
+}
+
+/// <summary>Outcome of an ingest: the canonical fact id and whether it was a duplicate.</summary>
+public readonly record struct DedupResult(Guid FactId, bool WasDuplicate, int MatchedLevel);

--- a/src/Deke.Core/Interfaces/IDomainTrustPolicyRepository.cs
+++ b/src/Deke.Core/Interfaces/IDomainTrustPolicyRepository.cs
@@ -1,0 +1,10 @@
+﻿using Deke.Core.Models;
+
+namespace Deke.Core.Interfaces;
+
+public interface IDomainTrustPolicyRepository
+{
+    Task<DomainTrustPolicy?> GetByDomainAsync(string domain, CancellationToken ct = default);
+    Task<List<DomainTrustPolicy>> GetAllAsync(CancellationToken ct = default);
+    Task UpsertAsync(DomainTrustPolicy policy, CancellationToken ct = default);
+}

--- a/src/Deke.Core/Interfaces/IDuplicateLinker.cs
+++ b/src/Deke.Core/Interfaces/IDuplicateLinker.cs
@@ -1,0 +1,17 @@
+﻿namespace Deke.Core.Interfaces;
+
+/// <summary>
+/// Records that a duplicate's source corroborates a canonical fact: writes a
+/// Corroboration provenance link and raises the canonical fact's corroboration
+/// count once per distinct source. Shared by the synchronous gateway and the
+/// asynchronous dedup jobs so the rule lives in one place.
+/// </summary>
+public interface IDuplicateLinker
+{
+    /// <summary>
+    /// Links <paramref name="duplicateSourceId"/> (when present) to the canonical
+    /// fact and increments its corroboration count if that source is new to it.
+    /// Returns true when the source was newly corroborating.
+    /// </summary>
+    Task<bool> CorroborateAsync(Guid canonicalId, Guid? duplicateSourceId, float confidence, CancellationToken ct = default);
+}

--- a/src/Deke.Core/Interfaces/IFactProvenanceRepository.cs
+++ b/src/Deke.Core/Interfaces/IFactProvenanceRepository.cs
@@ -1,0 +1,10 @@
+﻿using Deke.Core.Models;
+
+namespace Deke.Core.Interfaces;
+
+public interface IFactProvenanceRepository
+{
+    Task<List<FactProvenance>> GetByFactIdAsync(Guid factId, CancellationToken ct = default);
+    Task<Guid> AddAsync(FactProvenance provenance, CancellationToken ct = default);
+    Task DeleteAsync(Guid id, CancellationToken ct = default);
+}

--- a/src/Deke.Core/Interfaces/IFactRepository.cs
+++ b/src/Deke.Core/Interfaces/IFactRepository.cs
@@ -19,6 +19,15 @@ public interface IFactRepository
     Task UpdateAsync(Fact fact, CancellationToken ct = default);
     Task MarkOutdatedAsync(Guid id, string reason, CancellationToken ct = default);
 
+    // Deduplication (R2)
+    Task<Fact?> GetByContentHashAsync(string contentHash, string domain, CancellationToken ct = default);
+    Task<Fact?> GetByNormalizedHashAsync(string normalizedHash, string domain, CancellationToken ct = default);
+    Task IncrementCorroborationAsync(Guid id, CancellationToken ct = default);
+    Task SetDuplicateOfAsync(Guid id, Guid canonicalId, CancellationToken ct = default);
+    Task SetSimilarityHashAsync(Guid id, long similarityHash, CancellationToken ct = default);
+    Task<List<Fact>> GetPendingSimilarityAsync(int limit, CancellationToken ct = default);
+    Task<List<Fact>> GetPendingSemanticAsync(int limit, CancellationToken ct = default);
+
     Task<int> GetCountAsync(string domain, CancellationToken ct = default);
     Task<List<Fact>> GetRecentAsync(string domain, int days, int limit = 100, CancellationToken ct = default);
     Task<List<Fact>> GetWithoutRelationsAsync(string domain, int limit = 50, CancellationToken ct = default);

--- a/src/Deke.Core/Interfaces/IFactVersionRepository.cs
+++ b/src/Deke.Core/Interfaces/IFactVersionRepository.cs
@@ -1,0 +1,10 @@
+﻿using Deke.Core.Models;
+
+namespace Deke.Core.Interfaces;
+
+public interface IFactVersionRepository
+{
+    Task<List<FactVersion>> GetByFactIdAsync(Guid factId, CancellationToken ct = default);
+    Task<FactVersion?> GetAsOfAsync(Guid factId, DateTimeOffset asOf, CancellationToken ct = default);
+    Task<Guid> AddAsync(FactVersion version, CancellationToken ct = default);
+}

--- a/src/Deke.Core/Interfaces/ISimHasher.cs
+++ b/src/Deke.Core/Interfaces/ISimHasher.cs
@@ -1,0 +1,13 @@
+﻿namespace Deke.Core.Interfaces;
+
+/// <summary>
+/// Computes a 64-bit SimHash fingerprint for near-duplicate detection (level 4).
+/// </summary>
+public interface ISimHasher
+{
+    /// <summary>64-bit SimHash over token shingles of the content.</summary>
+    long Compute(string content);
+
+    /// <summary>Bit-count difference between two fingerprints (0 = identical).</summary>
+    int HammingDistance(long a, long b);
+}

--- a/src/Deke.Core/Models/DomainTrustPolicy.cs
+++ b/src/Deke.Core/Models/DomainTrustPolicy.cs
@@ -1,0 +1,12 @@
+﻿namespace Deke.Core.Models;
+
+public class DomainTrustPolicy
+{
+    public required string Domain { get; set; }
+    public bool RequirePrimarySource { get; set; }
+    public int MinCorroboration { get; set; }
+    public List<SourceTier> AutoAcceptTiers { get; set; } = [];
+    public List<SourceTier> FlagForReviewTiers { get; set; } = [];
+    public bool TemporalValidityRequired { get; set; }
+    public float MinConfidenceScore { get; set; }
+}

--- a/src/Deke.Core/Models/Fact.cs
+++ b/src/Deke.Core/Models/Fact.cs
@@ -24,6 +24,13 @@ public class Fact
     public bool ContradictionFlag { get; set; }
     public TrustState TrustState { get; set; } = TrustState.Unscored;
 
+    // Deduplication (R2): levels 2-3 exact hashes, level 4 similarity fingerprint,
+    // and a pointer to the canonical fact when this one is found to be a duplicate.
+    public string? ContentHash { get; set; }
+    public string? NormalizedHash { get; set; }
+    public long? SimilarityHash { get; set; }
+    public Guid? DuplicateOf { get; set; }
+
     // Navigation
     public Source? Source { get; set; }
 }

--- a/src/Deke.Core/Models/Fact.cs
+++ b/src/Deke.Core/Models/Fact.cs
@@ -19,6 +19,10 @@ public class Fact
     public string? OutdatedReason { get; set; }
     public DateTimeOffset? ValidFrom { get; set; }
     public DateTimeOffset? ValidUntil { get; set; }
+    public int CorroborationCount { get; set; }
+    public DateTimeOffset? LastVerifiedAt { get; set; }
+    public bool ContradictionFlag { get; set; }
+    public TrustState TrustState { get; set; } = TrustState.Unscored;
 
     // Navigation
     public Source? Source { get; set; }
@@ -28,4 +32,13 @@ public record ExtractedEntity
 {
     public required string Type { get; init; }
     public required string Value { get; init; }
+}
+
+public enum TrustState
+{
+    Unscored,
+    Accepted,
+    Flagged,
+    Contested,
+    Rejected
 }

--- a/src/Deke.Core/Models/FactProvenance.cs
+++ b/src/Deke.Core/Models/FactProvenance.cs
@@ -15,5 +15,7 @@ public enum ExtractionMethod
     RssHarvest,
     WebHarvest,
     ManualApi,
-    LlmExtract
+    LlmExtract,
+    FileHarvest,
+    Corroboration
 }

--- a/src/Deke.Core/Models/FactProvenance.cs
+++ b/src/Deke.Core/Models/FactProvenance.cs
@@ -1,0 +1,19 @@
+﻿namespace Deke.Core.Models;
+
+public class FactProvenance
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public required Guid FactId { get; set; }
+    public required Guid SourceId { get; set; }
+    public DateTimeOffset ExtractedAt { get; set; } = DateTimeOffset.UtcNow;
+    public ExtractionMethod ExtractionMethod { get; set; }
+    public float ExtractionConfidence { get; set; } = 1.0f;
+}
+
+public enum ExtractionMethod
+{
+    RssHarvest,
+    WebHarvest,
+    ManualApi,
+    LlmExtract
+}

--- a/src/Deke.Core/Models/FactVersion.cs
+++ b/src/Deke.Core/Models/FactVersion.cs
@@ -1,0 +1,19 @@
+﻿namespace Deke.Core.Models;
+
+public class FactVersion
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public required Guid FactId { get; set; }
+    public required string ContentSnapshot { get; set; }
+    public float[]? EmbeddingSnapshot { get; set; }
+    public DateTimeOffset ChangedAt { get; set; } = DateTimeOffset.UtcNow;
+    public ChangeReason ChangeReason { get; set; }
+}
+
+public enum ChangeReason
+{
+    SourceUpdate,
+    ManualCorrection,
+    Merge,
+    ContradictionResolution
+}

--- a/src/Deke.Core/Models/Source.cs
+++ b/src/Deke.Core/Models/Source.cs
@@ -17,6 +17,9 @@ public class Source
     public bool IsActive { get; set; } = true;
     public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
     public Dictionary<string, JsonElement> Metadata { get; set; } = [];
+    public SourceTier SourceTier { get; set; } = SourceTier.Unverified;
+    public string? IndependenceFingerprint { get; set; }
+    public DateTimeOffset? LastVerifiedAt { get; set; }
 
     // Navigation
     public List<Fact> Facts { get; set; } = [];
@@ -33,4 +36,12 @@ public enum SourceType
     Api,
     Manual,
     File
+}
+
+public enum SourceTier
+{
+    Primary,
+    Secondary,
+    Aggregated,
+    Unverified
 }

--- a/src/Deke.Infrastructure/Data/DapperConfig.cs
+++ b/src/Deke.Infrastructure/Data/DapperConfig.cs
@@ -33,6 +33,9 @@ public static class DapperConfig
         SqlMapper.AddTypeHandler(new JsonbTypeHandler<List<PeerDomainInfo>>());
         SqlMapper.AddTypeHandler(new JsonbTypeHandler<List<string>>());
 
+        // Trust policy type handlers
+        SqlMapper.AddTypeHandler(new JsonbTypeHandler<List<SourceTier>>());
+
         // Register UUID[] and REAL[] type handlers
         SqlMapper.AddTypeHandler(new GuidArrayTypeHandler());
         SqlMapper.AddTypeHandler(new FloatArrayTypeHandler());
@@ -42,6 +45,10 @@ public static class DapperConfig
         SqlMapper.AddTypeHandler(new EnumTypeHandler<PatternType>());
         SqlMapper.AddTypeHandler(new EnumTypeHandler<ConfidenceBand>());
         SqlMapper.AddTypeHandler(new EnumTypeHandler<Stakes>());
+        SqlMapper.AddTypeHandler(new EnumTypeHandler<SourceTier>());
+        SqlMapper.AddTypeHandler(new EnumTypeHandler<TrustState>());
+        SqlMapper.AddTypeHandler(new EnumTypeHandler<ExtractionMethod>());
+        SqlMapper.AddTypeHandler(new EnumTypeHandler<ChangeReason>());
 
         // Dapper: map underscore columns to PascalCase properties
         DefaultTypeMap.MatchNamesWithUnderscores = true;

--- a/src/Deke.Infrastructure/Ingestion/ContentHasher.cs
+++ b/src/Deke.Infrastructure/Ingestion/ContentHasher.cs
@@ -1,0 +1,52 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+using Deke.Core.Interfaces;
+
+namespace Deke.Infrastructure.Ingestion;
+
+/// <summary>
+/// SHA-256 exact-match hashing for dedup levels 2 (raw) and 3 (normalized).
+/// </summary>
+public class ContentHasher : IContentHasher
+{
+    public string ContentHash(string content) => Sha256Hex(content);
+
+    public string NormalizedHash(string content) => Sha256Hex(Normalize(content));
+
+    /// <summary>
+    /// NFKC-canonicalize, lowercase, drop punctuation/symbols, and collapse
+    /// whitespace to a single space so trivially-different renderings of the
+    /// same text hash identically.
+    /// </summary>
+    private static string Normalize(string content)
+    {
+        var canonical = content.Normalize(NormalizationForm.FormKC).ToLowerInvariant();
+        var sb = new StringBuilder(canonical.Length);
+        var lastWasSpace = false;
+
+        foreach (var ch in canonical)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                if (sb.Length > 0 && !lastWasSpace)
+                {
+                    sb.Append(' ');
+                    lastWasSpace = true;
+                }
+            }
+            else if (!char.IsPunctuation(ch) && !char.IsSymbol(ch))
+            {
+                sb.Append(ch);
+                lastWasSpace = false;
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string Sha256Hex(string text)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(text));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}

--- a/src/Deke.Infrastructure/Ingestion/DedupConfig.cs
+++ b/src/Deke.Infrastructure/Ingestion/DedupConfig.cs
@@ -1,0 +1,24 @@
+﻿namespace Deke.Infrastructure.Ingestion;
+
+/// <summary>
+/// Tunables for the asynchronous deduplication jobs (levels 4-5). Bound from
+/// the "Dedup" configuration section; the synchronous gateway (levels 1-3) does
+/// not consume these.
+/// </summary>
+public class DedupConfig
+{
+    /// <summary>Interval between level-4 (similarity hash) job cycles.</summary>
+    public int SimilarityIntervalMinutes { get; set; } = 30;
+
+    /// <summary>Interval between level-5 (semantic) job cycles.</summary>
+    public int SemanticIntervalMinutes { get; set; } = 60;
+
+    /// <summary>Facts processed per job cycle.</summary>
+    public int BatchSize { get; set; } = 200;
+
+    /// <summary>Max SimHash Hamming distance treated as a near-duplicate (level 4).</summary>
+    public int HammingThreshold { get; set; } = 3;
+
+    /// <summary>Min cosine similarity treated as a semantic duplicate (level 5).</summary>
+    public float SemanticThreshold { get; set; } = 0.92f;
+}

--- a/src/Deke.Infrastructure/Ingestion/DeduplicationService.cs
+++ b/src/Deke.Infrastructure/Ingestion/DeduplicationService.cs
@@ -14,17 +14,20 @@ public class DeduplicationService : IDeduplicationService
     private readonly IFactRepository _facts;
     private readonly IFactProvenanceRepository _provenance;
     private readonly IContentHasher _hasher;
+    private readonly IDuplicateLinker _linker;
     private readonly ILogger<DeduplicationService> _logger;
 
     public DeduplicationService(
         IFactRepository facts,
         IFactProvenanceRepository provenance,
         IContentHasher hasher,
+        IDuplicateLinker linker,
         ILogger<DeduplicationService> logger)
     {
         _facts = facts;
         _provenance = provenance;
         _hasher = hasher;
+        _linker = linker;
         _logger = logger;
     }
 
@@ -36,12 +39,12 @@ public class DeduplicationService : IDeduplicationService
         // Level 2: exact content match.
         var existing = await _facts.GetByContentHashAsync(contentHash, fact.Domain, ct);
         if (existing is not null)
-            return await CorroborateAsync(existing, fact, method, 2, ct);
+            return await CorroborateAsync(existing, fact, 2, ct);
 
         // Level 3: normalized match.
         existing = await _facts.GetByNormalizedHashAsync(normalizedHash, fact.Domain, ct);
         if (existing is not null)
-            return await CorroborateAsync(existing, fact, method, 3, ct);
+            return await CorroborateAsync(existing, fact, 3, ct);
 
         // Novel fact: persist with its hashes. similarity_hash is left NULL for
         // the level-4 job to fill.
@@ -55,7 +58,7 @@ public class DeduplicationService : IDeduplicationService
             // checks above and the insert: an equal fact landed first.
             var winner = await _facts.GetByIdAsync(storedId, ct);
             if (winner is not null)
-                return await CorroborateAsync(winner, fact, method, 3, ct);
+                return await CorroborateAsync(winner, fact, 3, ct);
         }
 
         await WriteProvenanceAsync(storedId, fact.SourceId, method, fact.Confidence, ct);
@@ -63,20 +66,9 @@ public class DeduplicationService : IDeduplicationService
     }
 
     private async Task<DedupResult> CorroborateAsync(
-        Fact canonical, Fact incoming, ExtractionMethod method, int level, CancellationToken ct)
+        Fact canonical, Fact incoming, int level, CancellationToken ct)
     {
-        // Only a genuinely new source raises the corroboration count; re-supply
-        // from a source already on the fact is a no-op beyond the provenance upsert.
-        if (incoming.SourceId is Guid source)
-        {
-            var links = await _provenance.GetByFactIdAsync(canonical.Id, ct);
-            var isNewSource = !links.Any(p => p.SourceId == source);
-
-            await WriteProvenanceAsync(canonical.Id, source, ExtractionMethod.Corroboration, incoming.Confidence, ct);
-
-            if (isNewSource)
-                await _facts.IncrementCorroborationAsync(canonical.Id, ct);
-        }
+        await _linker.CorroborateAsync(canonical.Id, incoming.SourceId, incoming.Confidence, ct);
 
         _logger.LogInformation(
             "Dedup L{Level}: fact {Incoming} duplicates {Canonical} in domain {Domain}",

--- a/src/Deke.Infrastructure/Ingestion/DeduplicationService.cs
+++ b/src/Deke.Infrastructure/Ingestion/DeduplicationService.cs
@@ -1,0 +1,102 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Deke.Infrastructure.Ingestion;
+
+/// <summary>
+/// Shared ingest gateway. Runs synchronous dedup levels 1-3 and records a
+/// provenance link on every insert; duplicates are discarded and the canonical
+/// fact is corroborated. Levels 4-5 run asynchronously in the worker.
+/// </summary>
+public class DeduplicationService : IDeduplicationService
+{
+    private readonly IFactRepository _facts;
+    private readonly IFactProvenanceRepository _provenance;
+    private readonly IContentHasher _hasher;
+    private readonly ILogger<DeduplicationService> _logger;
+
+    public DeduplicationService(
+        IFactRepository facts,
+        IFactProvenanceRepository provenance,
+        IContentHasher hasher,
+        ILogger<DeduplicationService> logger)
+    {
+        _facts = facts;
+        _provenance = provenance;
+        _hasher = hasher;
+        _logger = logger;
+    }
+
+    public async Task<DedupResult> IngestAsync(Fact fact, ExtractionMethod method, CancellationToken ct = default)
+    {
+        var contentHash = _hasher.ContentHash(fact.Content);
+        var normalizedHash = _hasher.NormalizedHash(fact.Content);
+
+        // Level 2: exact content match.
+        var existing = await _facts.GetByContentHashAsync(contentHash, fact.Domain, ct);
+        if (existing is not null)
+            return await CorroborateAsync(existing, fact, method, 2, ct);
+
+        // Level 3: normalized match.
+        existing = await _facts.GetByNormalizedHashAsync(normalizedHash, fact.Domain, ct);
+        if (existing is not null)
+            return await CorroborateAsync(existing, fact, method, 3, ct);
+
+        // Novel fact: persist with its hashes. similarity_hash is left NULL for
+        // the level-4 job to fill.
+        fact.ContentHash = contentHash;
+        fact.NormalizedHash = normalizedHash;
+        var storedId = await _facts.AddAsync(fact, ct);
+
+        if (storedId != fact.Id)
+        {
+            // Lost the (domain, normalized_hash) unique-index race between the
+            // checks above and the insert: an equal fact landed first.
+            var winner = await _facts.GetByIdAsync(storedId, ct);
+            if (winner is not null)
+                return await CorroborateAsync(winner, fact, method, 3, ct);
+        }
+
+        await WriteProvenanceAsync(storedId, fact.SourceId, method, fact.Confidence, ct);
+        return new DedupResult(storedId, false, 0);
+    }
+
+    private async Task<DedupResult> CorroborateAsync(
+        Fact canonical, Fact incoming, ExtractionMethod method, int level, CancellationToken ct)
+    {
+        // Only a genuinely new source raises the corroboration count; re-supply
+        // from a source already on the fact is a no-op beyond the provenance upsert.
+        if (incoming.SourceId is Guid source)
+        {
+            var links = await _provenance.GetByFactIdAsync(canonical.Id, ct);
+            var isNewSource = !links.Any(p => p.SourceId == source);
+
+            await WriteProvenanceAsync(canonical.Id, source, ExtractionMethod.Corroboration, incoming.Confidence, ct);
+
+            if (isNewSource)
+                await _facts.IncrementCorroborationAsync(canonical.Id, ct);
+        }
+
+        _logger.LogInformation(
+            "Dedup L{Level}: fact {Incoming} duplicates {Canonical} in domain {Domain}",
+            level, incoming.Id, canonical.Id, canonical.Domain);
+
+        return new DedupResult(canonical.Id, true, level);
+    }
+
+    private async Task WriteProvenanceAsync(
+        Guid factId, Guid? sourceId, ExtractionMethod method, float confidence, CancellationToken ct)
+    {
+        if (sourceId is not Guid source)
+            return;
+
+        await _provenance.AddAsync(new FactProvenance
+        {
+            FactId = factId,
+            SourceId = source,
+            ExtractionMethod = method,
+            ExtractionConfidence = confidence
+        }, ct);
+    }
+}

--- a/src/Deke.Infrastructure/Ingestion/DuplicateLinker.cs
+++ b/src/Deke.Infrastructure/Ingestion/DuplicateLinker.cs
@@ -1,0 +1,39 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+
+namespace Deke.Infrastructure.Ingestion;
+
+public class DuplicateLinker : IDuplicateLinker
+{
+    private readonly IFactRepository _facts;
+    private readonly IFactProvenanceRepository _provenance;
+
+    public DuplicateLinker(IFactRepository facts, IFactProvenanceRepository provenance)
+    {
+        _facts = facts;
+        _provenance = provenance;
+    }
+
+    public async Task<bool> CorroborateAsync(
+        Guid canonicalId, Guid? duplicateSourceId, float confidence, CancellationToken ct = default)
+    {
+        if (duplicateSourceId is not Guid source)
+            return false;
+
+        var links = await _provenance.GetByFactIdAsync(canonicalId, ct);
+        var isNewSource = !links.Any(p => p.SourceId == source);
+
+        await _provenance.AddAsync(new FactProvenance
+        {
+            FactId = canonicalId,
+            SourceId = source,
+            ExtractionMethod = ExtractionMethod.Corroboration,
+            ExtractionConfidence = confidence
+        }, ct);
+
+        if (isNewSource)
+            await _facts.IncrementCorroborationAsync(canonicalId, ct);
+
+        return isNewSource;
+    }
+}

--- a/src/Deke.Infrastructure/Ingestion/SimHasher.cs
+++ b/src/Deke.Infrastructure/Ingestion/SimHasher.cs
@@ -1,0 +1,68 @@
+﻿using System.Numerics;
+using System.Security.Cryptography;
+using System.Text;
+using Deke.Core.Interfaces;
+
+namespace Deke.Infrastructure.Ingestion;
+
+/// <summary>
+/// 64-bit SimHash over token shingles for near-duplicate detection (level 4).
+/// Similar texts produce fingerprints with a small Hamming distance.
+/// </summary>
+public class SimHasher : ISimHasher
+{
+    private const int ShingleSize = 3;
+
+    public long Compute(string content)
+    {
+        var tokens = Tokenize(content);
+        if (tokens.Count == 0)
+            return 0L;
+
+        var weights = new int[64];
+        foreach (var shingle in Shingles(tokens))
+        {
+            var hash = Hash64(shingle);
+            for (var bit = 0; bit < 64; bit++)
+            {
+                if (((hash >> bit) & 1UL) == 1UL)
+                    weights[bit]++;
+                else
+                    weights[bit]--;
+            }
+        }
+
+        ulong fingerprint = 0;
+        for (var bit = 0; bit < 64; bit++)
+        {
+            if (weights[bit] > 0)
+                fingerprint |= 1UL << bit;
+        }
+
+        return unchecked((long)fingerprint);
+    }
+
+    public int HammingDistance(long a, long b) =>
+        BitOperations.PopCount((ulong)(a ^ b));
+
+    private static List<string> Tokenize(string content) =>
+        [.. content.ToLowerInvariant().Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)];
+
+    private static IEnumerable<string> Shingles(List<string> tokens)
+    {
+        if (tokens.Count < ShingleSize)
+        {
+            yield return string.Join(' ', tokens);
+            yield break;
+        }
+
+        for (var i = 0; i <= tokens.Count - ShingleSize; i++)
+            yield return string.Join(' ', tokens.GetRange(i, ShingleSize));
+    }
+
+    private static ulong Hash64(string text)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(text));
+        return BitConverter.ToUInt64(bytes, 0);
+    }
+}

--- a/src/Deke.Infrastructure/Repositories/DomainTrustPolicyRepository.cs
+++ b/src/Deke.Infrastructure/Repositories/DomainTrustPolicyRepository.cs
@@ -1,0 +1,49 @@
+﻿using Dapper;
+using Deke.Core.Interfaces;
+using Deke.Core.Models;
+using Deke.Infrastructure.Data;
+
+namespace Deke.Infrastructure.Repositories;
+
+public class DomainTrustPolicyRepository : IDomainTrustPolicyRepository
+{
+    private readonly DbConnectionFactory _db;
+
+    public DomainTrustPolicyRepository(DbConnectionFactory db) => _db = db;
+
+    public async Task<DomainTrustPolicy?> GetByDomainAsync(string domain, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        return await conn.QueryFirstOrDefaultAsync<DomainTrustPolicy>(
+            "SELECT * FROM domain_trust_policy WHERE domain = @domain",
+            new { domain });
+    }
+
+    public async Task<List<DomainTrustPolicy>> GetAllAsync(CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        var results = await conn.QueryAsync<DomainTrustPolicy>(
+            "SELECT * FROM domain_trust_policy ORDER BY domain");
+        return results.AsList();
+    }
+
+    public async Task UpsertAsync(DomainTrustPolicy policy, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        await conn.ExecuteAsync(
+            """
+            INSERT INTO domain_trust_policy (domain, require_primary_source, min_corroboration,
+                auto_accept_tiers, flag_for_review_tiers, temporal_validity_required, min_confidence_score)
+            VALUES (@Domain, @RequirePrimarySource, @MinCorroboration,
+                @AutoAcceptTiers, @FlagForReviewTiers, @TemporalValidityRequired, @MinConfidenceScore)
+            ON CONFLICT (domain) DO UPDATE
+            SET require_primary_source = @RequirePrimarySource,
+                min_corroboration = @MinCorroboration,
+                auto_accept_tiers = @AutoAcceptTiers,
+                flag_for_review_tiers = @FlagForReviewTiers,
+                temporal_validity_required = @TemporalValidityRequired,
+                min_confidence_score = @MinConfidenceScore
+            """,
+            policy);
+    }
+}

--- a/src/Deke.Infrastructure/Repositories/FactProvenanceRepository.cs
+++ b/src/Deke.Infrastructure/Repositories/FactProvenanceRepository.cs
@@ -1,0 +1,46 @@
+﻿using Dapper;
+using Deke.Core.Interfaces;
+using Deke.Core.Models;
+using Deke.Infrastructure.Data;
+
+namespace Deke.Infrastructure.Repositories;
+
+public class FactProvenanceRepository : IFactProvenanceRepository
+{
+    private readonly DbConnectionFactory _db;
+
+    public FactProvenanceRepository(DbConnectionFactory db) => _db = db;
+
+    public async Task<List<FactProvenance>> GetByFactIdAsync(Guid factId, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        var results = await conn.QueryAsync<FactProvenance>(
+            "SELECT * FROM fact_provenance WHERE fact_id = @factId ORDER BY extracted_at DESC",
+            new { factId });
+        return results.AsList();
+    }
+
+    public async Task<Guid> AddAsync(FactProvenance provenance, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        await conn.ExecuteAsync(
+            """
+            INSERT INTO fact_provenance (id, fact_id, source_id, extracted_at, extraction_method, extraction_confidence)
+            VALUES (@Id, @FactId, @SourceId, @ExtractedAt, @ExtractionMethod, @ExtractionConfidence)
+            ON CONFLICT (fact_id, source_id) DO UPDATE
+            SET extracted_at = @ExtractedAt,
+                extraction_method = @ExtractionMethod,
+                extraction_confidence = @ExtractionConfidence
+            """,
+            provenance);
+        return provenance.Id;
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        await conn.ExecuteAsync(
+            "DELETE FROM fact_provenance WHERE id = @id",
+            new { id });
+    }
+}

--- a/src/Deke.Infrastructure/Repositories/FactRepository.cs
+++ b/src/Deke.Infrastructure/Repositories/FactRepository.cs
@@ -17,7 +17,8 @@ public class FactRepository : IFactRepository
         id, content, domain, confidence, source_id, related_fact_ids,
         entities, metadata, created_at, updated_at, is_outdated, outdated_reason,
         valid_from, valid_until, corroboration_count, last_verified_at,
-        contradiction_flag, trust_state
+        contradiction_flag, trust_state, content_hash, normalized_hash,
+        similarity_hash, duplicate_of
         """;
 
     private const string SelectAllColumns = SelectColumnsNoEmbedding + ", embedding";
@@ -83,40 +84,60 @@ public class FactRepository : IFactRepository
     {
         await using var conn = await _db.CreateConnectionAsync(ct);
         var embeddingParam = fact.Embedding is not null ? new Vector(fact.Embedding) : null;
-        await conn.ExecuteAsync(
+        var parameters = new
+        {
+            fact.Id,
+            fact.Content,
+            fact.Domain,
+            Embedding = embeddingParam,
+            fact.Confidence,
+            fact.SourceId,
+            fact.RelatedFactIds,
+            fact.Entities,
+            fact.Metadata,
+            fact.CreatedAt,
+            fact.UpdatedAt,
+            fact.IsOutdated,
+            fact.OutdatedReason,
+            fact.ValidFrom,
+            fact.ValidUntil,
+            fact.CorroborationCount,
+            fact.LastVerifiedAt,
+            fact.ContradictionFlag,
+            fact.TrustState,
+            fact.ContentHash,
+            fact.NormalizedHash,
+            fact.SimilarityHash,
+            fact.DuplicateOf
+        };
+
+        // ON CONFLICT guards the per-domain normalized-hash uniqueness. NULL
+        // normalized_hash rows never conflict (NULLs are distinct), so legacy /
+        // hash-less inserts always proceed. On a lost race the insert is
+        // suppressed and we return the winning row's id.
+        var insertedId = await conn.ExecuteScalarAsync<Guid?>(
             """
             INSERT INTO facts (id, content, domain, embedding, confidence, source_id,
                 related_fact_ids, entities, metadata, created_at, updated_at,
                 is_outdated, outdated_reason, valid_from, valid_until,
-                corroboration_count, last_verified_at, contradiction_flag, trust_state)
+                corroboration_count, last_verified_at, contradiction_flag, trust_state,
+                content_hash, normalized_hash, similarity_hash, duplicate_of)
             VALUES (@Id, @Content, @Domain, @Embedding::vector, @Confidence, @SourceId,
                 @RelatedFactIds, @Entities, @Metadata, @CreatedAt, @UpdatedAt,
                 @IsOutdated, @OutdatedReason, @ValidFrom, @ValidUntil,
-                @CorroborationCount, @LastVerifiedAt, @ContradictionFlag, @TrustState)
+                @CorroborationCount, @LastVerifiedAt, @ContradictionFlag, @TrustState,
+                @ContentHash, @NormalizedHash, @SimilarityHash, @DuplicateOf)
+            ON CONFLICT (domain, normalized_hash) DO NOTHING
+            RETURNING id
             """,
-            new
-            {
-                fact.Id,
-                fact.Content,
-                fact.Domain,
-                Embedding = embeddingParam,
-                fact.Confidence,
-                fact.SourceId,
-                fact.RelatedFactIds,
-                fact.Entities,
-                fact.Metadata,
-                fact.CreatedAt,
-                fact.UpdatedAt,
-                fact.IsOutdated,
-                fact.OutdatedReason,
-                fact.ValidFrom,
-                fact.ValidUntil,
-                fact.CorroborationCount,
-                fact.LastVerifiedAt,
-                fact.ContradictionFlag,
-                fact.TrustState
-            });
-        return fact.Id;
+            parameters);
+
+        if (insertedId is Guid id)
+            return id;
+
+        return await conn.ExecuteScalarAsync<Guid>(
+            "SELECT id FROM facts WHERE domain = @Domain AND normalized_hash = @NormalizedHash",
+            parameters);
     }
 
     public async Task UpdateAsync(Fact fact, CancellationToken ct = default)
@@ -143,7 +164,11 @@ public class FactRepository : IFactRepository
                 corroboration_count = @CorroborationCount,
                 last_verified_at = @LastVerifiedAt,
                 contradiction_flag = @ContradictionFlag,
-                trust_state = @TrustState
+                trust_state = @TrustState,
+                content_hash = @ContentHash,
+                normalized_hash = @NormalizedHash,
+                similarity_hash = @SimilarityHash,
+                duplicate_of = @DuplicateOf
             WHERE id = @Id
             """,
             new
@@ -165,7 +190,11 @@ public class FactRepository : IFactRepository
                 fact.CorroborationCount,
                 fact.LastVerifiedAt,
                 fact.ContradictionFlag,
-                fact.TrustState
+                fact.TrustState,
+                fact.ContentHash,
+                fact.NormalizedHash,
+                fact.SimilarityHash,
+                fact.DuplicateOf
             });
     }
 
@@ -234,6 +263,83 @@ public class FactRepository : IFactRepository
             WHERE NOT is_outdated
             GROUP BY domain
             """);
+        return results.AsList();
+    }
+
+    public async Task<Fact?> GetByContentHashAsync(string contentHash, string domain, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        return await conn.QueryFirstOrDefaultAsync<Fact>(
+            $"SELECT {SelectColumnsNoEmbedding} FROM facts WHERE content_hash = @contentHash AND domain = @domain LIMIT 1",
+            new { contentHash, domain });
+    }
+
+    public async Task<Fact?> GetByNormalizedHashAsync(string normalizedHash, string domain, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        return await conn.QueryFirstOrDefaultAsync<Fact>(
+            $"SELECT {SelectColumnsNoEmbedding} FROM facts WHERE normalized_hash = @normalizedHash AND domain = @domain LIMIT 1",
+            new { normalizedHash, domain });
+    }
+
+    public async Task IncrementCorroborationAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        await conn.ExecuteAsync(
+            """
+            UPDATE facts
+            SET corroboration_count = corroboration_count + 1,
+                last_verified_at = @now
+            WHERE id = @id
+            """,
+            new { id, now = DateTimeOffset.UtcNow });
+    }
+
+    public async Task SetDuplicateOfAsync(Guid id, Guid canonicalId, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        await conn.ExecuteAsync(
+            "UPDATE facts SET duplicate_of = @canonicalId, updated_at = @now WHERE id = @id",
+            new { id, canonicalId, now = DateTimeOffset.UtcNow });
+    }
+
+    public async Task SetSimilarityHashAsync(Guid id, long similarityHash, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        await conn.ExecuteAsync(
+            "UPDATE facts SET similarity_hash = @similarityHash WHERE id = @id",
+            new { id, similarityHash });
+    }
+
+    public async Task<List<Fact>> GetPendingSimilarityAsync(int limit, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        var results = await conn.QueryAsync<Fact>(
+            $"""
+            SELECT {SelectColumnsNoEmbedding} FROM facts
+            WHERE similarity_hash IS NULL
+              AND duplicate_of IS NULL
+              AND is_outdated = FALSE
+            ORDER BY created_at DESC
+            LIMIT @limit
+            """,
+            new { limit });
+        return results.AsList();
+    }
+
+    public async Task<List<Fact>> GetPendingSemanticAsync(int limit, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        var results = await conn.QueryAsync<Fact>(
+            $"""
+            SELECT {SelectAllColumns} FROM facts
+            WHERE embedding IS NOT NULL
+              AND duplicate_of IS NULL
+              AND is_outdated = FALSE
+            ORDER BY created_at DESC
+            LIMIT @limit
+            """,
+            new { limit });
         return results.AsList();
     }
 }

--- a/src/Deke.Infrastructure/Repositories/FactRepository.cs
+++ b/src/Deke.Infrastructure/Repositories/FactRepository.cs
@@ -16,7 +16,8 @@ public class FactRepository : IFactRepository
         """
         id, content, domain, confidence, source_id, related_fact_ids,
         entities, metadata, created_at, updated_at, is_outdated, outdated_reason,
-        valid_from, valid_until
+        valid_from, valid_until, corroboration_count, last_verified_at,
+        contradiction_flag, trust_state
         """;
 
     private const string SelectAllColumns = SelectColumnsNoEmbedding + ", embedding";
@@ -86,10 +87,12 @@ public class FactRepository : IFactRepository
             """
             INSERT INTO facts (id, content, domain, embedding, confidence, source_id,
                 related_fact_ids, entities, metadata, created_at, updated_at,
-                is_outdated, outdated_reason, valid_from, valid_until)
+                is_outdated, outdated_reason, valid_from, valid_until,
+                corroboration_count, last_verified_at, contradiction_flag, trust_state)
             VALUES (@Id, @Content, @Domain, @Embedding::vector, @Confidence, @SourceId,
                 @RelatedFactIds, @Entities, @Metadata, @CreatedAt, @UpdatedAt,
-                @IsOutdated, @OutdatedReason, @ValidFrom, @ValidUntil)
+                @IsOutdated, @OutdatedReason, @ValidFrom, @ValidUntil,
+                @CorroborationCount, @LastVerifiedAt, @ContradictionFlag, @TrustState)
             """,
             new
             {
@@ -107,7 +110,11 @@ public class FactRepository : IFactRepository
                 fact.IsOutdated,
                 fact.OutdatedReason,
                 fact.ValidFrom,
-                fact.ValidUntil
+                fact.ValidUntil,
+                fact.CorroborationCount,
+                fact.LastVerifiedAt,
+                fact.ContradictionFlag,
+                fact.TrustState
             });
         return fact.Id;
     }
@@ -132,7 +139,11 @@ public class FactRepository : IFactRepository
                 is_outdated = @IsOutdated,
                 outdated_reason = @OutdatedReason,
                 valid_from = @ValidFrom,
-                valid_until = @ValidUntil
+                valid_until = @ValidUntil,
+                corroboration_count = @CorroborationCount,
+                last_verified_at = @LastVerifiedAt,
+                contradiction_flag = @ContradictionFlag,
+                trust_state = @TrustState
             WHERE id = @Id
             """,
             new
@@ -150,7 +161,11 @@ public class FactRepository : IFactRepository
                 fact.IsOutdated,
                 fact.OutdatedReason,
                 fact.ValidFrom,
-                fact.ValidUntil
+                fact.ValidUntil,
+                fact.CorroborationCount,
+                fact.LastVerifiedAt,
+                fact.ContradictionFlag,
+                fact.TrustState
             });
     }
 

--- a/src/Deke.Infrastructure/Repositories/FactVersionRepository.cs
+++ b/src/Deke.Infrastructure/Repositories/FactVersionRepository.cs
@@ -1,0 +1,60 @@
+﻿using Dapper;
+using Deke.Core.Interfaces;
+using Deke.Core.Models;
+using Deke.Infrastructure.Data;
+using Pgvector;
+
+namespace Deke.Infrastructure.Repositories;
+
+public class FactVersionRepository : IFactVersionRepository
+{
+    private readonly DbConnectionFactory _db;
+
+    public FactVersionRepository(DbConnectionFactory db) => _db = db;
+
+    private const string SelectColumns =
+        "id, fact_id, content_snapshot, changed_at, change_reason";
+
+    public async Task<List<FactVersion>> GetByFactIdAsync(Guid factId, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        var results = await conn.QueryAsync<FactVersion>(
+            $"SELECT {SelectColumns} FROM fact_version WHERE fact_id = @factId ORDER BY changed_at DESC",
+            new { factId });
+        return results.AsList();
+    }
+
+    public async Task<FactVersion?> GetAsOfAsync(Guid factId, DateTimeOffset asOf, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        return await conn.QueryFirstOrDefaultAsync<FactVersion>(
+            $"""
+            SELECT {SelectColumns} FROM fact_version
+            WHERE fact_id = @factId AND changed_at <= @asOf
+            ORDER BY changed_at DESC
+            LIMIT 1
+            """,
+            new { factId, asOf });
+    }
+
+    public async Task<Guid> AddAsync(FactVersion version, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        var embeddingParam = version.EmbeddingSnapshot is not null ? new Vector(version.EmbeddingSnapshot) : null;
+        await conn.ExecuteAsync(
+            """
+            INSERT INTO fact_version (id, fact_id, content_snapshot, embedding_snapshot, changed_at, change_reason)
+            VALUES (@Id, @FactId, @ContentSnapshot, @Embedding::vector, @ChangedAt, @ChangeReason)
+            """,
+            new
+            {
+                version.Id,
+                version.FactId,
+                version.ContentSnapshot,
+                Embedding = embeddingParam,
+                version.ChangedAt,
+                version.ChangeReason
+            });
+        return version.Id;
+    }
+}

--- a/src/Deke.Infrastructure/Repositories/SourceRepository.cs
+++ b/src/Deke.Infrastructure/Repositories/SourceRepository.cs
@@ -64,10 +64,12 @@ public class SourceRepository : ISourceRepository
             """
             INSERT INTO sources (id, url, domain, name, type, check_interval,
                 last_checked_at, last_changed_at, content_hash, credibility,
-                is_active, created_at, metadata)
+                is_active, created_at, metadata, source_tier, independence_fingerprint,
+                last_verified_at)
             VALUES (@Id, @Url, @Domain, @Name, @Type, @CheckInterval,
                 @LastCheckedAt, @LastChangedAt, @ContentHash, @Credibility,
-                @IsActive, @CreatedAt, @Metadata)
+                @IsActive, @CreatedAt, @Metadata, @SourceTier, @IndependenceFingerprint,
+                @LastVerifiedAt)
             """,
             source);
         return source.Id;
@@ -89,7 +91,10 @@ public class SourceRepository : ISourceRepository
                 content_hash = @ContentHash,
                 credibility = @Credibility,
                 is_active = @IsActive,
-                metadata = @Metadata
+                metadata = @Metadata,
+                source_tier = @SourceTier,
+                independence_fingerprint = @IndependenceFingerprint,
+                last_verified_at = @LastVerifiedAt
             WHERE id = @Id
             """,
             source);

--- a/src/Deke.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Deke.Infrastructure/ServiceCollectionExtensions.cs
@@ -66,6 +66,7 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IContentHasher, ContentHasher>();
         services.AddSingleton<ISimHasher, SimHasher>();
+        services.AddScoped<IDuplicateLinker, DuplicateLinker>();
         services.AddScoped<IDeduplicationService, DeduplicationService>();
 
         return services;

--- a/src/Deke.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Deke.Infrastructure/ServiceCollectionExtensions.cs
@@ -35,6 +35,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IFactRelationRepository, FactRelationRepository>();
         services.AddScoped<ILearningLogRepository, LearningLogRepository>();
         services.AddScoped<IInteractionLogRepository, InteractionLogRepository>();
+        services.AddScoped<IFactProvenanceRepository, FactProvenanceRepository>();
+        services.AddScoped<IFactVersionRepository, FactVersionRepository>();
+        services.AddScoped<IDomainTrustPolicyRepository, DomainTrustPolicyRepository>();
 
         return services;
     }

--- a/src/Deke.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Deke.Infrastructure/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Deke.Infrastructure.Embeddings;
 using Deke.Infrastructure.Extraction;
 using Deke.Infrastructure.Federation;
 using Deke.Infrastructure.Harvesters;
+using Deke.Infrastructure.Ingestion;
 using Deke.Infrastructure.Repositories;
 using Deke.Infrastructure.Trust;
 using Microsoft.Extensions.AI;
@@ -54,6 +55,18 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(config);
         services.AddSingleton<IEmbeddingService, OnnxEmbeddingService>();
         services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>, OnnxEmbeddingGenerator>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddDekeDedup(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<DedupConfig>(configuration.GetSection("Dedup"));
+
+        services.AddSingleton<IContentHasher, ContentHasher>();
+        services.AddSingleton<ISimHasher, SimHasher>();
+        services.AddScoped<IDeduplicationService, DeduplicationService>();
 
         return services;
     }

--- a/src/Deke.Mcp/Program.cs
+++ b/src/Deke.Mcp/Program.cs
@@ -24,6 +24,7 @@ var connectionString = builder.Configuration.GetConnectionString("Deke")
 
 builder.Services.AddDekeInfrastructure(connectionString);
 builder.Services.AddDekeEmbeddings(builder.Configuration);
+builder.Services.AddDekeDedup(builder.Configuration);
 builder.Services.AddDekeFederation(builder.Configuration);
 builder.Services.AddDekeAdvisory(builder.Configuration);
 

--- a/src/Deke.Mcp/Tools/FactTools.cs
+++ b/src/Deke.Mcp/Tools/FactTools.cs
@@ -11,7 +11,7 @@ public class FactTools
 {
     [McpServerTool(Name = "add_fact"), Description("Add a new fact to the knowledge base")]
     public static async Task<string> AddFact(
-        IFactRepository factRepository,
+        IDeduplicationService dedup,
         IEmbeddingService embeddingService,
         [Description("The fact content text")] string content,
         [Description("The knowledge domain this fact belongs to")] string domain,
@@ -28,9 +28,11 @@ public class FactTools
             Confidence = confidence
         };
 
-        var id = await factRepository.AddAsync(fact, ct);
+        var result = await dedup.IngestAsync(fact, ExtractionMethod.ManualApi, ct);
 
-        return $"Fact added successfully.\nID: {id}\nDomain: {domain}\nConfidence: {confidence:F2}";
+        return result.WasDuplicate
+            ? $"Fact matched an existing entry (duplicate).\nID: {result.FactId}\nDomain: {domain}"
+            : $"Fact added successfully.\nID: {result.FactId}\nDomain: {domain}\nConfidence: {confidence:F2}";
     }
 
     [McpServerTool(Name = "get_fact"), Description("Get a specific fact by its ID")]

--- a/src/Deke.Worker/Deke.Worker.csproj
+++ b/src/Deke.Worker/Deke.Worker.csproj
@@ -14,4 +14,8 @@
     <ProjectReference Include="..\Deke.Infrastructure\Deke.Infrastructure.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Deke.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Deke.Worker/Program.cs
+++ b/src/Deke.Worker/Program.cs
@@ -16,6 +16,7 @@ var connectionString = builder.Configuration.GetConnectionString("Deke")
 builder.Services.AddDekeInfrastructure(connectionString);
 builder.Services.AddDekeEmbeddings(builder.Configuration);
 builder.Services.AddDekeHarvesters();
+builder.Services.AddDekeDedup(builder.Configuration);
 builder.Services.AddDekeFederation(builder.Configuration);
 
 // PatternDiscoveryService summarizes fact clusters via the same keyed IChatClient
@@ -44,6 +45,8 @@ builder.Services.AddHostedService<SourceMonitorService>();
 builder.Services.AddHostedService<PatternDiscoveryService>();
 builder.Services.AddHostedService<LearningCycleService>();
 builder.Services.AddHostedService<PeerHealthCheckService>();
+builder.Services.AddHostedService<SimilarityDedupService>();
+builder.Services.AddHostedService<SemanticDedupService>();
 
 var host = builder.Build();
 host.Run();

--- a/src/Deke.Worker/Services/BootstrapIngestionService.cs
+++ b/src/Deke.Worker/Services/BootstrapIngestionService.cs
@@ -10,7 +10,7 @@ public class BootstrapIngestionService
     private static readonly string[] BootstrapPaths = ["docs", "thoughts"];
 
     private readonly ISourceRepository _sourceRepo;
-    private readonly IFactRepository _factRepo;
+    private readonly IDeduplicationService _dedup;
     private readonly IEnumerable<IHarvester> _harvesters;
     private readonly IChunker _chunker;
     private readonly IExtractionService _extractionService;
@@ -19,7 +19,7 @@ public class BootstrapIngestionService
 
     public BootstrapIngestionService(
         ISourceRepository sourceRepo,
-        IFactRepository factRepo,
+        IDeduplicationService dedup,
         IEnumerable<IHarvester> harvesters,
         IChunker chunker,
         IExtractionService extractionService,
@@ -27,7 +27,7 @@ public class BootstrapIngestionService
         ILogger<BootstrapIngestionService> logger)
     {
         _sourceRepo = sourceRepo;
-        _factRepo = factRepo;
+        _dedup = dedup;
         _harvesters = harvesters;
         _chunker = chunker;
         _extractionService = extractionService;
@@ -98,8 +98,9 @@ public class BootstrapIngestionService
                         Entities = extracted.Entities
                     };
 
-                    await _factRepo.AddAsync(fact, ct);
-                    factsAdded++;
+                    var dedupResult = await _dedup.IngestAsync(fact, ExtractionMethod.FileHarvest, ct);
+                    if (!dedupResult.WasDuplicate)
+                        factsAdded++;
                 }
             }
         }

--- a/src/Deke.Worker/Services/SemanticDedupService.cs
+++ b/src/Deke.Worker/Services/SemanticDedupService.cs
@@ -49,7 +49,7 @@ public class SemanticDedupService : BackgroundService
         }
     }
 
-    private async Task RunCycleAsync(CancellationToken ct)
+    internal async Task RunCycleAsync(CancellationToken ct)
     {
         using var scope = _serviceProvider.CreateScope();
         var factRepo = scope.ServiceProvider.GetRequiredService<IFactRepository>();

--- a/src/Deke.Worker/Services/SemanticDedupService.cs
+++ b/src/Deke.Worker/Services/SemanticDedupService.cs
@@ -1,0 +1,113 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+using Deke.Infrastructure.Ingestion;
+using Microsoft.Extensions.Options;
+
+namespace Deke.Worker.Services;
+
+/// <summary>
+/// Deduplication level 5 (async): links facts whose embedding is within the
+/// configured cosine threshold of an earlier fact to that canonical fact.
+/// </summary>
+public class SemanticDedupService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<SemanticDedupService> _logger;
+    private readonly DedupConfig _config;
+
+    public SemanticDedupService(
+        IServiceProvider serviceProvider,
+        ILogger<SemanticDedupService> logger,
+        IOptions<DedupConfig> config)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+        _config = config.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("SemanticDedupService started");
+        var interval = TimeSpan.FromMinutes(_config.SemanticIntervalMinutes);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RunCycleAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in semantic dedup cycle");
+            }
+
+            await Task.Delay(interval, stoppingToken);
+        }
+    }
+
+    private async Task RunCycleAsync(CancellationToken ct)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var factRepo = scope.ServiceProvider.GetRequiredService<IFactRepository>();
+        var linker = scope.ServiceProvider.GetRequiredService<IDuplicateLinker>();
+        var learningLogRepo = scope.ServiceProvider.GetRequiredService<ILearningLogRepository>();
+
+        var pending = await factRepo.GetPendingSemanticAsync(_config.BatchSize, ct);
+        if (pending.Count == 0)
+            return;
+
+        foreach (var domainGroup in pending.GroupBy(f => f.Domain))
+        {
+            var domain = domainGroup.Key;
+            var log = new LearningLog
+            {
+                Domain = domain,
+                CycleType = "semantic-dedup",
+                StartedAt = DateTimeOffset.UtcNow
+            };
+
+            try
+            {
+                var duplicates = 0;
+                foreach (var fact in domainGroup)
+                {
+                    if (fact.Embedding is not { Length: > 0 })
+                        continue;
+
+                    var matches = await factRepo.SearchAsync(
+                        fact.Embedding, domain, limit: 5, minSimilarity: _config.SemanticThreshold, ct: ct);
+
+                    // Canonical = most-similar strictly-older fact, so a pair collapses
+                    // onto its earlier member only (never marks both as duplicates).
+                    var canonical = matches
+                        .Where(m => m.Id != fact.Id && m.CreatedAt < fact.CreatedAt)
+                        .OrderByDescending(m => m.Similarity)
+                        .FirstOrDefault();
+
+                    if (canonical is not null)
+                    {
+                        await factRepo.SetDuplicateOfAsync(fact.Id, canonical.Id, ct);
+                        await linker.CorroborateAsync(canonical.Id, fact.SourceId, fact.Confidence, ct);
+                        duplicates++;
+                    }
+                }
+
+                log.FactsUpdated = duplicates;
+                log.CompletedAt = DateTimeOffset.UtcNow;
+                log.Notes = $"Checked {domainGroup.Count()} facts, linked {duplicates} semantic duplicates";
+            }
+            catch (Exception ex)
+            {
+                log.ErrorMessage = ex.Message;
+                log.CompletedAt = DateTimeOffset.UtcNow;
+                _logger.LogError(ex, "Error in semantic dedup for domain {Domain}", domain);
+            }
+
+            await learningLogRepo.AddAsync(log, ct);
+        }
+    }
+}

--- a/src/Deke.Worker/Services/SimilarityDedupService.cs
+++ b/src/Deke.Worker/Services/SimilarityDedupService.cs
@@ -1,0 +1,122 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+using Deke.Infrastructure.Ingestion;
+using Microsoft.Extensions.Options;
+
+namespace Deke.Worker.Services;
+
+/// <summary>
+/// Deduplication level 4 (async): stamps a SimHash on facts that lack one and
+/// links near-duplicates (Hamming distance within the configured threshold) to
+/// their canonical fact.
+/// </summary>
+public class SimilarityDedupService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<SimilarityDedupService> _logger;
+    private readonly DedupConfig _config;
+
+    public SimilarityDedupService(
+        IServiceProvider serviceProvider,
+        ILogger<SimilarityDedupService> logger,
+        IOptions<DedupConfig> config)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+        _config = config.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("SimilarityDedupService started");
+        var interval = TimeSpan.FromMinutes(_config.SimilarityIntervalMinutes);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RunCycleAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in similarity dedup cycle");
+            }
+
+            await Task.Delay(interval, stoppingToken);
+        }
+    }
+
+    private async Task RunCycleAsync(CancellationToken ct)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var factRepo = scope.ServiceProvider.GetRequiredService<IFactRepository>();
+        var simHasher = scope.ServiceProvider.GetRequiredService<ISimHasher>();
+        var linker = scope.ServiceProvider.GetRequiredService<IDuplicateLinker>();
+        var learningLogRepo = scope.ServiceProvider.GetRequiredService<ILearningLogRepository>();
+
+        var pending = await factRepo.GetPendingSimilarityAsync(_config.BatchSize, ct);
+        if (pending.Count == 0)
+            return;
+
+        foreach (var domainGroup in pending.GroupBy(f => f.Domain))
+        {
+            var domain = domainGroup.Key;
+            var log = new LearningLog
+            {
+                Domain = domain,
+                CycleType = "similarity-dedup",
+                StartedAt = DateTimeOffset.UtcNow
+            };
+
+            try
+            {
+                // Already-hashed, non-duplicate facts in this domain are the corpus
+                // each pending fact is compared against.
+                var corpus = (await factRepo.GetByDomainAsync(domain, 1000, ct))
+                    .Where(f => f.SimilarityHash is not null && f.DuplicateOf is null)
+                    .ToList();
+
+                var duplicates = 0;
+                foreach (var fact in domainGroup)
+                {
+                    var hash = simHasher.Compute(fact.Content);
+
+                    var canonical = corpus.FirstOrDefault(c =>
+                        c.Id != fact.Id &&
+                        simHasher.HammingDistance(hash, c.SimilarityHash!.Value) <= _config.HammingThreshold);
+
+                    await factRepo.SetSimilarityHashAsync(fact.Id, hash, ct);
+                    fact.SimilarityHash = hash;
+
+                    if (canonical is not null)
+                    {
+                        await factRepo.SetDuplicateOfAsync(fact.Id, canonical.Id, ct);
+                        await linker.CorroborateAsync(canonical.Id, fact.SourceId, fact.Confidence, ct);
+                        duplicates++;
+                    }
+                    else
+                    {
+                        // Unique so far: joins the corpus for later facts in this batch.
+                        corpus.Add(fact);
+                    }
+                }
+
+                log.FactsUpdated = duplicates;
+                log.CompletedAt = DateTimeOffset.UtcNow;
+                log.Notes = $"Hashed {domainGroup.Count()} facts, linked {duplicates} near-duplicates";
+            }
+            catch (Exception ex)
+            {
+                log.ErrorMessage = ex.Message;
+                log.CompletedAt = DateTimeOffset.UtcNow;
+                _logger.LogError(ex, "Error in similarity dedup for domain {Domain}", domain);
+            }
+
+            await learningLogRepo.AddAsync(log, ct);
+        }
+    }
+}

--- a/src/Deke.Worker/Services/SimilarityDedupService.cs
+++ b/src/Deke.Worker/Services/SimilarityDedupService.cs
@@ -50,7 +50,7 @@ public class SimilarityDedupService : BackgroundService
         }
     }
 
-    private async Task RunCycleAsync(CancellationToken ct)
+    internal async Task RunCycleAsync(CancellationToken ct)
     {
         using var scope = _serviceProvider.CreateScope();
         var factRepo = scope.ServiceProvider.GetRequiredService<IFactRepository>();

--- a/src/Deke.Worker/Services/SourceMonitorService.cs
+++ b/src/Deke.Worker/Services/SourceMonitorService.cs
@@ -42,7 +42,7 @@ public class SourceMonitorService : BackgroundService
     {
         using var scope = _serviceProvider.CreateScope();
         var sourceRepo = scope.ServiceProvider.GetRequiredService<ISourceRepository>();
-        var factRepo = scope.ServiceProvider.GetRequiredService<IFactRepository>();
+        var dedup = scope.ServiceProvider.GetRequiredService<IDeduplicationService>();
         var harvesters = scope.ServiceProvider.GetRequiredService<IEnumerable<IHarvester>>();
         var embeddingService = scope.ServiceProvider.GetRequiredService<IEmbeddingService>();
         var extractionService = scope.ServiceProvider.GetRequiredService<IExtractionService>();
@@ -103,8 +103,9 @@ public class SourceMonitorService : BackgroundService
                                     Entities = extracted.Entities
                                 };
 
-                                await factRepo.AddAsync(fact, ct);
-                                factsAdded++;
+                                var dedupResult = await dedup.IngestAsync(fact, MapMethod(source.Type), ct);
+                                if (!dedupResult.WasDuplicate)
+                                    factsAdded++;
                             }
                         }
                     }
@@ -120,4 +121,12 @@ public class SourceMonitorService : BackgroundService
             }
         }
     }
+
+    private static ExtractionMethod MapMethod(SourceType type) => type switch
+    {
+        SourceType.Rss => ExtractionMethod.RssHarvest,
+        SourceType.WebPage => ExtractionMethod.WebHarvest,
+        SourceType.File => ExtractionMethod.FileHarvest,
+        _ => ExtractionMethod.ManualApi
+    };
 }

--- a/src/Deke.Worker/appsettings.json
+++ b/src/Deke.Worker/appsettings.json
@@ -22,6 +22,13 @@
     "OllamaBaseUrl": "http://localhost:11434",
     "OllamaModel": "qwen2.5:7b"
   },
+  "Dedup": {
+    "SimilarityIntervalMinutes": 30,
+    "SemanticIntervalMinutes": 60,
+    "BatchSize": 200,
+    "HammingThreshold": 3,
+    "SemanticThreshold": 0.92
+  },
   "Federation": {
     "Enabled": false,
     "InstanceId": "default",

--- a/tests/Deke.Tests/AdvisoryPipelineTests.cs
+++ b/tests/Deke.Tests/AdvisoryPipelineTests.cs
@@ -186,5 +186,12 @@ public class AdvisoryPipelineTests
         public Task<List<Fact>> GetRecentAsync(string domain, int days, int limit = 100, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetWithoutRelationsAsync(string domain, int limit = 50, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<DomainStats>> GetDomainStatsAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<Fact?> GetByContentHashAsync(string contentHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<Fact?> GetByNormalizedHashAsync(string normalizedHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task IncrementCorroborationAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task SetDuplicateOfAsync(Guid id, Guid canonicalId, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task SetSimilarityHashAsync(Guid id, long similarityHash, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingSimilarityAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingSemanticAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
     }
 }

--- a/tests/Deke.Tests/ApiEndpointTests.cs
+++ b/tests/Deke.Tests/ApiEndpointTests.cs
@@ -284,6 +284,13 @@ public class ApiEndpointTests
         public Task<List<Fact>> GetRecentAsync(string domain, int days, int limit = 100, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetWithoutRelationsAsync(string domain, int limit = 50, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<DomainStats>> GetDomainStatsAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<Fact?> GetByContentHashAsync(string contentHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<Fact?> GetByNormalizedHashAsync(string normalizedHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task IncrementCorroborationAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task SetDuplicateOfAsync(Guid id, Guid canonicalId, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task SetSimilarityHashAsync(Guid id, long similarityHash, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingSimilarityAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingSemanticAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
     }
 
     private sealed class FakeSourceRepository : ISourceRepository

--- a/tests/Deke.Tests/BootstrapIngestionTests.cs
+++ b/tests/Deke.Tests/BootstrapIngestionTests.cs
@@ -131,5 +131,12 @@ public class BootstrapIngestionTests : IDisposable
         public Task<List<Fact>> GetRecentAsync(string domain, int days, int limit = 100, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetWithoutRelationsAsync(string domain, int limit = 50, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<DomainStats>> GetDomainStatsAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<Fact?> GetByContentHashAsync(string contentHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<Fact?> GetByNormalizedHashAsync(string normalizedHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task IncrementCorroborationAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task SetDuplicateOfAsync(Guid id, Guid canonicalId, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task SetSimilarityHashAsync(Guid id, long similarityHash, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingSimilarityAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingSemanticAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
     }
 }

--- a/tests/Deke.Tests/BootstrapIngestionTests.cs
+++ b/tests/Deke.Tests/BootstrapIngestionTests.cs
@@ -60,12 +60,21 @@ public class BootstrapIngestionTests : IDisposable
 
         return new BootstrapIngestionService(
             sourceRepo,
-            factRepo,
+            new FakeDeduplicationService(factRepo),
             harvesters,
             new IdentityChunker(),
             new SimpleExtractionService(),
             new FakeEmbeddingService(),
             NullLogger<BootstrapIngestionService>.Instance);
+    }
+
+    private sealed class FakeDeduplicationService(IFactRepository facts) : IDeduplicationService
+    {
+        public async Task<DedupResult> IngestAsync(Fact fact, ExtractionMethod method, CancellationToken ct = default)
+        {
+            var id = await facts.AddAsync(fact, ct);
+            return new DedupResult(id, false, 0);
+        }
     }
 
     private sealed class IdentityChunker : IChunker

--- a/tests/Deke.Tests/ContentHasherTests.cs
+++ b/tests/Deke.Tests/ContentHasherTests.cs
@@ -1,0 +1,37 @@
+﻿using Deke.Infrastructure.Ingestion;
+
+namespace Deke.Tests;
+
+public class ContentHasherTests
+{
+    private readonly ContentHasher _hasher = new();
+
+    [Fact]
+    public void ContentHash_IsStableAndCaseSensitive()
+    {
+        Assert.Equal(_hasher.ContentHash("Ice fishing tips"), _hasher.ContentHash("Ice fishing tips"));
+        Assert.NotEqual(_hasher.ContentHash("Ice fishing tips"), _hasher.ContentHash("ice fishing tips"));
+    }
+
+    [Fact]
+    public void ContentHash_IsSixtyFourHexChars()
+    {
+        var hash = _hasher.ContentHash("anything");
+        Assert.Equal(64, hash.Length);
+        Assert.Matches("^[0-9a-f]{64}$", hash);
+    }
+
+    [Fact]
+    public void NormalizedHash_IgnoresWhitespaceCaseAndTrailingPunctuation()
+    {
+        var a = _hasher.NormalizedHash("Ice fishing  TIPS!");
+        var b = _hasher.NormalizedHash("   ice fishing tips   ");
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void NormalizedHash_DiffersForDifferentContent()
+    {
+        Assert.NotEqual(_hasher.NormalizedHash("ice fishing"), _hasher.NormalizedHash("fly fishing"));
+    }
+}

--- a/tests/Deke.Tests/DeduplicationServiceTests.cs
+++ b/tests/Deke.Tests/DeduplicationServiceTests.cs
@@ -1,0 +1,100 @@
+﻿using Deke.Core.Models;
+using Deke.Infrastructure.Ingestion;
+using Deke.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Deke.Tests;
+
+public class DeduplicationServiceTests
+{
+    private readonly InMemoryFactRepository _facts = new();
+    private readonly FakeFactProvenanceRepository _provenance = new();
+    private readonly DeduplicationService _service;
+
+    public DeduplicationServiceTests()
+    {
+        var linker = new DuplicateLinker(_facts, _provenance);
+        _service = new DeduplicationService(
+            _facts, _provenance, new ContentHasher(), linker,
+            NullLogger<DeduplicationService>.Instance);
+    }
+
+    private static Fact NewFact(string content, string domain = "fishing", Guid? sourceId = null) => new()
+    {
+        Content = content,
+        Domain = domain,
+        SourceId = sourceId ?? Guid.NewGuid(),
+        Confidence = 0.9f
+    };
+
+    [Fact]
+    public async Task IngestAsync_NovelFact_InsertsWithHashesAndFirstSightingProvenance()
+    {
+        var fact = NewFact("Walleye bite best at dusk.");
+
+        var result = await _service.IngestAsync(fact, ExtractionMethod.RssHarvest);
+
+        Assert.False(result.WasDuplicate);
+        Assert.Equal(fact.Id, result.FactId);
+        var stored = _facts.Get(fact.Id);
+        Assert.NotNull(stored.ContentHash);
+        Assert.NotNull(stored.NormalizedHash);
+        var prov = Assert.Single(_provenance.Records);
+        Assert.Equal(ExtractionMethod.RssHarvest, prov.ExtractionMethod);
+    }
+
+    [Fact]
+    public async Task IngestAsync_ExactDuplicateFromNewSource_DiscardsAndCorroborates()
+    {
+        var first = NewFact("Walleye bite best at dusk.");
+        await _service.IngestAsync(first, ExtractionMethod.RssHarvest);
+
+        var dup = NewFact("Walleye bite best at dusk.");
+        var result = await _service.IngestAsync(dup, ExtractionMethod.WebHarvest);
+
+        Assert.True(result.WasDuplicate);
+        Assert.Equal(2, result.MatchedLevel);
+        Assert.Equal(first.Id, result.FactId);
+        Assert.Single(_facts.All);
+        Assert.Equal(1, _facts.Get(first.Id).CorroborationCount);
+        Assert.Equal(2, _provenance.Records.Count);
+        Assert.Contains(_provenance.Records, p => p.ExtractionMethod == ExtractionMethod.Corroboration);
+    }
+
+    [Fact]
+    public async Task IngestAsync_NormalizedDuplicate_MatchesAtLevel3()
+    {
+        await _service.IngestAsync(NewFact("Walleye bite best at dusk."), ExtractionMethod.RssHarvest);
+
+        var dup = NewFact("walleye   bite BEST at dusk!!");
+        var result = await _service.IngestAsync(dup, ExtractionMethod.WebHarvest);
+
+        Assert.True(result.WasDuplicate);
+        Assert.Equal(3, result.MatchedLevel);
+        Assert.Single(_facts.All);
+    }
+
+    [Fact]
+    public async Task IngestAsync_SameContentDifferentDomain_IsNotDuplicate()
+    {
+        await _service.IngestAsync(NewFact("Cast into the wind.", domain: "fishing"), ExtractionMethod.RssHarvest);
+
+        var other = NewFact("Cast into the wind.", domain: "sailing");
+        var result = await _service.IngestAsync(other, ExtractionMethod.RssHarvest);
+
+        Assert.False(result.WasDuplicate);
+        Assert.Equal(2, _facts.All.Count);
+    }
+
+    [Fact]
+    public async Task IngestAsync_DuplicateFromSameSource_DoesNotDoubleCountCorroboration()
+    {
+        var source = Guid.NewGuid();
+        await _service.IngestAsync(NewFact("Tie a clinch knot.", sourceId: source), ExtractionMethod.RssHarvest);
+
+        await _service.IngestAsync(NewFact("Tie a clinch knot.", sourceId: source), ExtractionMethod.RssHarvest);
+
+        var canonical = _facts.All.Single();
+        Assert.Equal(0, canonical.CorroborationCount);
+    }
+}

--- a/tests/Deke.Tests/Fakes/FakeFactProvenanceRepository.cs
+++ b/tests/Deke.Tests/Fakes/FakeFactProvenanceRepository.cs
@@ -1,0 +1,39 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+
+namespace Deke.Tests.Fakes;
+
+/// <summary>
+/// Records provenance writes for assertions and upserts on (FactId, SourceId)
+/// to mirror the real ON CONFLICT behavior.
+/// </summary>
+public sealed class FakeFactProvenanceRepository : IFactProvenanceRepository
+{
+    public List<FactProvenance> Records { get; } = [];
+
+    public Task<List<FactProvenance>> GetByFactIdAsync(Guid factId, CancellationToken ct = default) =>
+        Task.FromResult(Records.Where(p => p.FactId == factId).ToList());
+
+    public Task<Guid> AddAsync(FactProvenance provenance, CancellationToken ct = default)
+    {
+        var existing = Records.FirstOrDefault(p =>
+            p.FactId == provenance.FactId && p.SourceId == provenance.SourceId);
+
+        if (existing is not null)
+        {
+            existing.ExtractionMethod = provenance.ExtractionMethod;
+            existing.ExtractionConfidence = provenance.ExtractionConfidence;
+            existing.ExtractedAt = provenance.ExtractedAt;
+            return Task.FromResult(existing.Id);
+        }
+
+        Records.Add(provenance);
+        return Task.FromResult(provenance.Id);
+    }
+
+    public Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        Records.RemoveAll(p => p.Id == id);
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Deke.Tests/Fakes/FakeLearningLogRepository.cs
+++ b/tests/Deke.Tests/Fakes/FakeLearningLogRepository.cs
@@ -1,0 +1,19 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+
+namespace Deke.Tests.Fakes;
+
+public sealed class FakeLearningLogRepository : ILearningLogRepository
+{
+    public List<LearningLog> Logs { get; } = [];
+
+    public Task<Guid> AddAsync(LearningLog log, CancellationToken ct = default)
+    {
+        Logs.Add(log);
+        return Task.FromResult(log.Id);
+    }
+
+    public Task UpdateAsync(LearningLog log, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<List<LearningLog>> GetByDomainAsync(string domain, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<LearningLog?> GetLatestAsync(string domain, CancellationToken ct = default) => throw new NotImplementedException();
+}

--- a/tests/Deke.Tests/Fakes/InMemoryFactRepository.cs
+++ b/tests/Deke.Tests/Fakes/InMemoryFactRepository.cs
@@ -1,0 +1,132 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+
+namespace Deke.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="IFactRepository"/> for dedup tests. Implements the
+/// dedup-relevant behavior (hash lookups, ON CONFLICT on domain+normalized
+/// hash, corroboration, duplicate marking, cosine search) with real semantics;
+/// unrelated members throw.
+/// </summary>
+public sealed class InMemoryFactRepository : IFactRepository
+{
+    private readonly Dictionary<Guid, Fact> _store = new();
+
+    public IReadOnlyCollection<Fact> All => _store.Values;
+    public Fact Get(Guid id) => _store[id];
+
+    public void Seed(params Fact[] facts)
+    {
+        foreach (var fact in facts)
+            _store[fact.Id] = fact;
+    }
+
+    public Task<Guid> AddAsync(Fact fact, CancellationToken ct = default)
+    {
+        // Emulate UNIQUE(domain, normalized_hash) ON CONFLICT DO NOTHING.
+        if (fact.NormalizedHash is not null)
+        {
+            var clash = _store.Values.FirstOrDefault(f =>
+                f.Domain == fact.Domain && f.NormalizedHash == fact.NormalizedHash);
+            if (clash is not null)
+                return Task.FromResult(clash.Id);
+        }
+
+        _store[fact.Id] = fact;
+        return Task.FromResult(fact.Id);
+    }
+
+    public Task<Fact?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        Task.FromResult(_store.TryGetValue(id, out var f) ? f : null);
+
+    public Task<Fact?> GetByContentHashAsync(string contentHash, string domain, CancellationToken ct = default) =>
+        Task.FromResult(_store.Values.FirstOrDefault(f => f.Domain == domain && f.ContentHash == contentHash));
+
+    public Task<Fact?> GetByNormalizedHashAsync(string normalizedHash, string domain, CancellationToken ct = default) =>
+        Task.FromResult(_store.Values.FirstOrDefault(f => f.Domain == domain && f.NormalizedHash == normalizedHash));
+
+    public Task IncrementCorroborationAsync(Guid id, CancellationToken ct = default)
+    {
+        if (_store.TryGetValue(id, out var f))
+            f.CorroborationCount++;
+        return Task.CompletedTask;
+    }
+
+    public Task SetDuplicateOfAsync(Guid id, Guid canonicalId, CancellationToken ct = default)
+    {
+        if (_store.TryGetValue(id, out var f))
+            f.DuplicateOf = canonicalId;
+        return Task.CompletedTask;
+    }
+
+    public Task SetSimilarityHashAsync(Guid id, long similarityHash, CancellationToken ct = default)
+    {
+        if (_store.TryGetValue(id, out var f))
+            f.SimilarityHash = similarityHash;
+        return Task.CompletedTask;
+    }
+
+    public Task<List<Fact>> GetByDomainAsync(string domain, int limit = 100, CancellationToken ct = default) =>
+        Task.FromResult(_store.Values.Where(f => f.Domain == domain)
+            .OrderByDescending(f => f.CreatedAt).Take(limit).ToList());
+
+    public Task<List<Fact>> GetPendingSimilarityAsync(int limit, CancellationToken ct = default) =>
+        Task.FromResult(_store.Values
+            .Where(f => f.SimilarityHash is null && f.DuplicateOf is null && !f.IsOutdated)
+            .OrderByDescending(f => f.CreatedAt).Take(limit).ToList());
+
+    public Task<List<Fact>> GetPendingSemanticAsync(int limit, CancellationToken ct = default) =>
+        Task.FromResult(_store.Values
+            .Where(f => f.Embedding is { Length: > 0 } && f.DuplicateOf is null && !f.IsOutdated)
+            .OrderByDescending(f => f.CreatedAt).Take(limit).ToList());
+
+    public Task<List<FactSearchResult>> SearchAsync(
+        float[] embedding, string? domain, int limit = 10, float minSimilarity = 0.5f, CancellationToken ct = default)
+    {
+        var results = _store.Values
+            .Where(f => f.Embedding is { Length: > 0 } && (domain is null || f.Domain == domain))
+            .Select(f => (Fact: f, Sim: Cosine(embedding, f.Embedding!)))
+            .Where(x => x.Sim > minSimilarity)
+            .OrderByDescending(x => x.Sim)
+            .Take(limit)
+            .Select(x => new FactSearchResult
+            {
+                Id = x.Fact.Id,
+                Content = x.Fact.Content,
+                Domain = x.Fact.Domain,
+                Confidence = x.Fact.Confidence,
+                Similarity = x.Sim,
+                SourceId = x.Fact.SourceId,
+                CreatedAt = x.Fact.CreatedAt
+            })
+            .ToList();
+        return Task.FromResult(results);
+    }
+
+    public Task UpdateAsync(Fact fact, CancellationToken ct = default)
+    {
+        _store[fact.Id] = fact;
+        return Task.CompletedTask;
+    }
+
+    private static float Cosine(float[] a, float[] b)
+    {
+        float dot = 0, na = 0, nb = 0;
+        var len = Math.Min(a.Length, b.Length);
+        for (var i = 0; i < len; i++)
+        {
+            dot += a[i] * b[i];
+            na += a[i] * a[i];
+            nb += b[i] * b[i];
+        }
+        return na == 0 || nb == 0 ? 0 : dot / (MathF.Sqrt(na) * MathF.Sqrt(nb));
+    }
+
+    public Task<List<Fact>> GetBySourceAsync(Guid sourceId, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task MarkOutdatedAsync(Guid id, string reason, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<int> GetCountAsync(string domain, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<List<Fact>> GetRecentAsync(string domain, int days, int limit = 100, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<List<Fact>> GetWithoutRelationsAsync(string domain, int limit = 50, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<List<DomainStats>> GetDomainStatsAsync(CancellationToken ct = default) => throw new NotImplementedException();
+}

--- a/tests/Deke.Tests/InteractionLoggingTests.cs
+++ b/tests/Deke.Tests/InteractionLoggingTests.cs
@@ -94,6 +94,13 @@ public class InteractionLoggingTests
         public Task<List<Fact>> GetRecentAsync(string domain, int days, int limit = 100, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetWithoutRelationsAsync(string domain, int limit = 50, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<DomainStats>> GetDomainStatsAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<Fact?> GetByContentHashAsync(string contentHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<Fact?> GetByNormalizedHashAsync(string normalizedHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task IncrementCorroborationAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task SetDuplicateOfAsync(Guid id, Guid canonicalId, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task SetSimilarityHashAsync(Guid id, long similarityHash, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingSimilarityAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingSemanticAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
     }
 
     private sealed class FakeInteractionLogRepository : IInteractionLogRepository

--- a/tests/Deke.Tests/SemanticDedupServiceTests.cs
+++ b/tests/Deke.Tests/SemanticDedupServiceTests.cs
@@ -1,0 +1,78 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+using Deke.Infrastructure.Ingestion;
+using Deke.Tests.Fakes;
+using Deke.Worker.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Deke.Tests;
+
+public class SemanticDedupServiceTests
+{
+    private readonly InMemoryFactRepository _facts = new();
+    private readonly FakeFactProvenanceRepository _provenance = new();
+
+    private SemanticDedupService BuildService(DedupConfig config)
+    {
+        var provider = new ServiceCollection()
+            .AddScoped<IFactRepository>(_ => _facts)
+            .AddScoped<IFactProvenanceRepository>(_ => _provenance)
+            .AddScoped<ILearningLogRepository>(_ => new FakeLearningLogRepository())
+            .AddScoped<IDuplicateLinker, DuplicateLinker>()
+            .BuildServiceProvider();
+
+        return new SemanticDedupService(
+            provider, NullLogger<SemanticDedupService>.Instance, Options.Create(config));
+    }
+
+    [Fact]
+    public async Task RunCycleAsync_LinksSemanticNeighborToOlderCanonical()
+    {
+        var sourceA = Guid.NewGuid();
+        var sourceB = Guid.NewGuid();
+
+        var canonical = new Fact
+        {
+            Content = "Walleye feed most actively at dusk.",
+            Domain = "fishing",
+            SourceId = sourceA,
+            Confidence = 0.9f,
+            Embedding = [1f, 0f, 0f, 0f],
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-1)
+        };
+        var semanticDup = new Fact
+        {
+            Content = "At dusk walleye are at their most active feeding.",
+            Domain = "fishing",
+            SourceId = sourceB,
+            Confidence = 0.9f,
+            Embedding = [0.99f, 0.14f, 0f, 0f],
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        var unrelated = new Fact
+        {
+            Content = "Sailboats need wind to move.",
+            Domain = "fishing",
+            SourceId = Guid.NewGuid(),
+            Confidence = 0.9f,
+            Embedding = [0f, 0f, 1f, 0f],
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        _facts.Seed(canonical, semanticDup, unrelated);
+
+        var service = BuildService(new DedupConfig { SemanticThreshold = 0.92f, BatchSize = 100 });
+        await service.RunCycleAsync(CancellationToken.None);
+
+        // Newer semantic neighbor collapses onto the older canonical; canonical is untouched.
+        Assert.Equal(canonical.Id, _facts.Get(semanticDup.Id).DuplicateOf);
+        Assert.Null(_facts.Get(canonical.Id).DuplicateOf);
+        Assert.Equal(1, _facts.Get(canonical.Id).CorroborationCount);
+        Assert.Contains(_provenance.Records,
+            p => p.FactId == canonical.Id && p.SourceId == sourceB && p.ExtractionMethod == ExtractionMethod.Corroboration);
+
+        // Dissimilar fact is left alone.
+        Assert.Null(_facts.Get(unrelated.Id).DuplicateOf);
+    }
+}

--- a/tests/Deke.Tests/SimHasherTests.cs
+++ b/tests/Deke.Tests/SimHasherTests.cs
@@ -1,0 +1,29 @@
+﻿using Deke.Infrastructure.Ingestion;
+
+namespace Deke.Tests;
+
+public class SimHasherTests
+{
+    private readonly SimHasher _hasher = new();
+
+    [Fact]
+    public void HammingDistance_OfIdenticalHashes_IsZero()
+    {
+        var h = _hasher.Compute("the quick brown fox jumps over the lazy dog");
+        Assert.Equal(0, _hasher.HammingDistance(h, h));
+    }
+
+    [Fact]
+    public void NearDuplicate_IsCloserThanUnrelated()
+    {
+        var baseline = _hasher.Compute("the quick brown fox jumps over the lazy dog in the yard");
+        var near = _hasher.Compute("the quick brown fox jumps over the lazy dog in the garden");
+        var far = _hasher.Compute("quarterly earnings beat analyst expectations across the technology sector");
+
+        var nearDist = _hasher.HammingDistance(baseline, near);
+        var farDist = _hasher.HammingDistance(baseline, far);
+
+        Assert.True(nearDist < farDist, $"near={nearDist} far={farDist}");
+        Assert.True(nearDist <= 12, $"near={nearDist}");
+    }
+}

--- a/tests/Deke.Tests/SimilarityDedupServiceTests.cs
+++ b/tests/Deke.Tests/SimilarityDedupServiceTests.cs
@@ -1,0 +1,80 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+using Deke.Infrastructure.Ingestion;
+using Deke.Tests.Fakes;
+using Deke.Worker.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Deke.Tests;
+
+public class SimilarityDedupServiceTests
+{
+    private readonly InMemoryFactRepository _facts = new();
+    private readonly FakeFactProvenanceRepository _provenance = new();
+
+    private SimilarityDedupService BuildService(DedupConfig config)
+    {
+        var provider = new ServiceCollection()
+            .AddScoped<IFactRepository>(_ => _facts)
+            .AddScoped<IFactProvenanceRepository>(_ => _provenance)
+            .AddScoped<ILearningLogRepository>(_ => new FakeLearningLogRepository())
+            .AddScoped<ISimHasher, SimHasher>()
+            .AddScoped<IDuplicateLinker, DuplicateLinker>()
+            .BuildServiceProvider();
+
+        return new SimilarityDedupService(
+            provider, NullLogger<SimilarityDedupService>.Instance, Options.Create(config));
+    }
+
+    [Fact]
+    public async Task RunCycleAsync_LinksNearDuplicateToCanonicalAndStampsHash()
+    {
+        var simHasher = new SimHasher();
+        var sourceA = Guid.NewGuid();
+        var sourceB = Guid.NewGuid();
+
+        var canonicalText = "the quick brown fox jumps over the lazy dog beside the river bank";
+        var canonical = new Fact
+        {
+            Content = canonicalText,
+            Domain = "fishing",
+            SourceId = sourceA,
+            Confidence = 0.9f,
+            SimilarityHash = simHasher.Compute(canonicalText),
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-1)
+        };
+        var nearDup = new Fact
+        {
+            Content = "the quick brown fox jumps over the lazy dog beside the river shore",
+            Domain = "fishing",
+            SourceId = sourceB,
+            Confidence = 0.9f,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        var unrelated = new Fact
+        {
+            Content = "quarterly earnings beat analyst expectations across the technology sector",
+            Domain = "fishing",
+            SourceId = Guid.NewGuid(),
+            Confidence = 0.9f,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        _facts.Seed(canonical, nearDup, unrelated);
+
+        var service = BuildService(new DedupConfig { HammingThreshold = 12, BatchSize = 100 });
+        await service.RunCycleAsync(CancellationToken.None);
+
+        // Near-duplicate linked to the canonical, hash stamped, canonical corroborated.
+        Assert.Equal(canonical.Id, _facts.Get(nearDup.Id).DuplicateOf);
+        Assert.NotNull(_facts.Get(nearDup.Id).SimilarityHash);
+        Assert.Equal(1, _facts.Get(canonical.Id).CorroborationCount);
+        Assert.Contains(_provenance.Records,
+            p => p.FactId == canonical.Id && p.SourceId == sourceB && p.ExtractionMethod == ExtractionMethod.Corroboration);
+
+        // Unrelated fact is hashed but not linked.
+        Assert.Null(_facts.Get(unrelated.Id).DuplicateOf);
+        Assert.NotNull(_facts.Get(unrelated.Id).SimilarityHash);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the five-level fact deduplication pipeline: levels 1–3 (content hash, normalized hash) run synchronously at ingest via a shared `DeduplicationService`; levels 4 (SimHash near-duplicate) and 5 (semantic cosine ≥ 0.92) run asynchronously as Worker background jobs.
- Routes **all four** fact-insert entry points (SourceMonitor, Bootstrap, API `AddFact`, MCP `add_fact`) through one dedup gateway, so no insert bypasses dedup + provenance.
- On a duplicate hit, writes a provenance link to `fact_provenance` and bumps `corroboration_count` — closing the P1-1 gap where `FactProvenanceRepository.AddAsync` had zero callers.

## Acceptance Criteria
- [x] All five levels active — 1–3 sync, 4–5 async background jobs
- [x] Automated test per level
- [x] Duplicate detection records a provenance link via `fact_provenance`
- [x] `dotnet build` clean; `dotnet test` green (93 passed, +13 from the 80 baseline)
- [x] Background jobs registered/scheduled (`AddHostedService`)

## Key Decisions
- **SimHash** (64-bit, Hamming distance) for L4 — single `BIGINT` column, cheap compare.
- **`UNIQUE(domain, normalized_hash)`** + `ON CONFLICT DO NOTHING` — hard guard against the concurrent Worker/API/MCP insert race; NULL-tolerant for legacy rows.
- **Discard + corroborate** — sync hits skip insert; async hits set `duplicate_of`; both link provenance.
- **Provenance on every insert** (first sighting + duplicate links).
- Backfill of pre-existing facts is **out of scope** (follow-up).

## Changes
39 files, +1380/-46. Highlights:
- Schema: `init.sql` fact hash columns + indexes; idempotent `scripts/migrations/2026-07-21-r2-dedup.sql` for the live container.
- Core: `IContentHasher`, `ISimHasher`, `IDeduplicationService`, `IDuplicateLinker`; `Fact` hash fields; `ExtractionMethod` +2 members.
- Infrastructure: `ContentHasher`, `SimHasher`, `DeduplicationService`, `DuplicateLinker`, `DedupConfig`; `FactRepository` hash persistence + `ON CONFLICT` upsert + candidate queries.
- Worker: `SimilarityDedupService` (L4), `SemanticDedupService` (L5).
- Tests: per-level coverage + `FakeFactProvenanceRepository`, `InMemoryFactRepository`.

## Testing
- `dotnet build`: 0 errors, 7 warnings.
- `dotnet test`: 93 passed, 0 failed.
- Manual: apply `scripts/migrations/2026-07-21-r2-dedup.sql` to the live container (additive/idempotent), then ingest duplicate content and confirm a single canonical fact with a `fact_provenance` corroboration row.

## Notes / Deviations
- **Deviation**: introduced `IDuplicateLinker`/`DuplicateLinker` (not in the original plan) to share the "link provenance + set `duplicate_of` + corroborate" logic across the sync service and both async jobs.
- **Follow-up**: `docs/architecture/decisions.md` still needs the combined R2 entry (SimHash choice, per-domain uniqueness, every-insert provenance) — to be added via doc-maintainer per repo governance.
- **Follow-up**: retroactive dedup backfill of pre-existing facts (deliberately out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)