### PR TITLE
feat: P1-2 quality pipeline — trust evaluation, contradiction detection, review queue

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,7 +49,7 @@ NOW (no unmet dependencies, parallelizable)
 
 NEXT (dependencies above; P1-1 done 2026-07-21, so R2/P1-2 are now available)
   R2    five-level deduplication       ← done 2026-07-22
-  P1-2  quality pipeline               ← unblocked, depends only on P1-1
+  P1-2  quality pipeline               ← done 2026-07-22
   RES-1 ─→ (spawned design packet: hybrid retrieval)
   R4   cross-encoder re-ranking        (R1 done; consult RES-1 findings)
   R5   PDF + Markdown ingestion        (R1 done)
@@ -196,7 +196,7 @@ TRIGGER-GATED (sized only when the trigger fires)
   discard-and-corroborate, extracted `IDuplicateLinker`). Retroactive backfill
   of pre-existing NULL-hash facts deferred out of R2.
 
-### P1-2: Quality pipeline
+### P1-2: Quality pipeline — done (2026-07-22)
 
 - **Goal:** Review queue (`GET /api/review-queue`), temporal-validity
   handling, contradiction detection. Opens with the scheduled OI-07
@@ -210,6 +210,25 @@ TRIGGER-GATED (sized only when the trigger fires)
 - **Tier:** strongest available, extended thinking (contains open design).
 - **Done when:** review-queue endpoint live; contradiction detection behind a
   version-aware policy or an explicit deferral ADR; OI-07/OI-08 dispositioned.
+- **Status:** Done 2026-07-22. Activates the P1-1 trust schema into working
+  behavior: `ITrustEvaluator` (policy-driven `Unscored` → `Accepted`/
+  `Flagged` classification, fails open to `Accepted` when a domain has no
+  configured policy), `TrustStateEvaluationService` and
+  `ContradictionDetectionService` (`Deke.Worker` background jobs mirroring
+  R2's L4/L5 shape), `GET /api/review-queue`, and `GET`/`PUT
+  /api/domains/{domain}/trust-policy` (closing the P1-1 gap where the
+  trust-policy repository shipped with no endpoints wired to it).
+  Contradiction detection ships a basic, non-version-aware
+  embedding-similarity heuristic (0.75-0.90 band, kept below L5's 0.92
+  dedup threshold) rather than the full version-aware design. OI-07
+  (version-aware contradiction) and OI-08 (fact retirement/archival) were
+  reviewed as scheduled and dispositioned as deferred, not built — see
+  [decisions.md](architecture/decisions.md) 2026-07-22 entry,
+  [ADR-0012](adr/ADR-0012-oi-07-version-aware-contradiction-deferred.md),
+  and [ADR-0013](adr/ADR-0013-oi-08-fact-retirement-archival-deferred.md).
+  Verified: build green, 115/115 tests passing. `init.sql`'s new partial
+  index (`idx_facts_trust_state`) is not yet applied to the live
+  `deke-postgres` container — pending follow-up.
 
 ### R4: Cross-encoder re-ranking
 
@@ -361,3 +380,4 @@ beats speculative sizing.
 | 2026-07-14 | Overhaul dissolved | All 8 exit criteria passed (OP-012). `overhaul/` archived in place — kept for history, excluded from agent context budgets. Repo tagged `overhaul-complete` (overhaul packet OP-013). |
 | 2026-07-21 | P1-1 done | Trust and provenance schema, reconciled scope (see [decisions.md](architecture/decisions.md) 2026-07-21 entry): 3 new tables (`fact_provenance`, `fact_version`, `domain_trust_policy`), new trust columns on `sources`/`facts`, matching models/repositories/DI. Schema only — algorithms deferred to P1-2. Build green, 80/80 tests passing. R2 and P1-2 unblocked. |
 | 2026-07-22 | R2 done | Five-level deduplication (see [decisions.md](architecture/decisions.md) 2026-07-22 entry): L1–L3 hash checks sync at ingest, L4 SimHash near-dup + L5 semantic ≥ 0.92 async jobs. All fact inserts across Worker/API/MCP routed through one dedup gateway with per-domain `UNIQUE(domain, normalized_hash)`; provenance written on every insert; discard-and-corroborate duplicate resolution via extracted `IDuplicateLinker`. Per-level test coverage added. Merged to main via PR #31. Retroactive backfill deferred. |
+| 2026-07-22 | P1-2 done | Quality pipeline activates P1-1's trust schema (see [decisions.md](architecture/decisions.md) 2026-07-22 entry): `ITrustEvaluator` policy-driven `Unscored` → `Accepted`/`Flagged` classification (fails open when a domain has no configured policy); `TrustStateEvaluationService` and `ContradictionDetectionService` background jobs; `GET /api/review-queue` and `GET`/`PUT /api/domains/{domain}/trust-policy` endpoints, closing a P1-1 gap. Contradiction detection is a basic, non-version-aware heuristic. OI-07 (version-aware contradiction) and OI-08 (fact retirement/archival) reviewed and dispositioned as deferred via [ADR-0012](adr/ADR-0012-oi-07-version-aware-contradiction-deferred.md) and [ADR-0013](adr/ADR-0013-oi-08-fact-retirement-archival-deferred.md). Build green, 115/115 tests passing. |

--- a/docs/adr/ADR-0012-oi-07-version-aware-contradiction-deferred.md
+++ b/docs/adr/ADR-0012-oi-07-version-aware-contradiction-deferred.md
@@ -1,0 +1,57 @@
+# ADR-0012: OI-07 (version-aware contradiction resolution) deferred beyond P1-2
+
+- **Status:** accepted
+- **Type:** design
+- **Decision:** Defer version-aware contradiction resolution beyond P1-2.
+  `ContradictionDetectionService` ships only a basic, non-version-aware
+  embedding-similarity heuristic (candidate band 0.75-0.90, kept below L5
+  dedup's 0.92 threshold); the version tagging schema
+  (`applies_to_version`, `deprecated_after_version`), version-scoped
+  detection, and query-time version resolver described in OI-07 are not
+  built.
+- **Why:**
+  - OI-07 (`decisions.md`) already framed this precisely: "requires version
+    tagging schema (P1-1). Detection logic can be added in P1-2," with
+    revisit trigger "...or P1-2 is being implemented" — that trigger is
+    this packet.
+  - P1-1 shipped schema-only (per its 2026-07-21 `decisions.md` entry) and
+    did not include a version-tagging schema — `applies_to_version`/
+    `deprecated_after_version` do not exist on `facts`. Building
+    version-scoped detection now would require adding that schema
+    mid-packet, which is schema design work beyond P1-2's scope as sized in
+    [ROADMAP.md](../ROADMAP.md) ("review queue, temporal-validity handling,
+    contradiction detection").
+  - The Self-Evolving AI Agents Survey (arXiv:2508.07407), cited in OI-07,
+    treats version-aware contradiction resolution without ground truth as
+    an open research problem, not an implementation detail — not something
+    to build speculatively inside a quality-pipeline activation packet.
+  - The basic heuristic's similarity band (0.75 lower bound, 0.90 upper
+    bound) is deliberately kept below L5 semantic dedup's 0.92 threshold so
+    the two systems — deduplication and contradiction detection — never
+    compete for the same fact pair.
+- **Rejected alternatives:**
+  - Build the full version tagging schema and version-scoped detection now,
+    since the packet was already touching trust/contradiction code —
+    rejected: this is unsized schema-design work (a P1-1-shaped change)
+    folded into a P1-2 activation packet; OI-07 explicitly separates schema
+    (P1-1) from detection logic (P1-2), and the schema half was never done.
+  - Ship contradiction detection with no similarity band at all (flag every
+    candidate above L5's dedup threshold) — rejected: collapses into
+    deduplication's territory and would re-flag the exact near-duplicates
+    L4/L5 already resolve, rather than the semantically-similar-but-
+    conflicting facts contradiction detection is meant to catch.
+  - Skip contradiction detection entirely until version-awareness is
+    designed — rejected: leaves P1-2's `Contested` trust state and the
+    review queue with no producer. The basic heuristic delivers real value
+    now (catching same-version contradictions) even though it cannot yet
+    distinguish version-progressive facts from genuine conflicts.
+- **Consequences:** OI-07 remains open in `decisions.md`'s Open Design
+  Questions, with its revisit trigger narrowed going forward to: an
+  observed false-positive contradiction rate on version-progressive facts
+  in practice (e.g. a .NET 6 fact wrongly flagged against a .NET 9 fact),
+  or a future packet explicitly sized to build the version-tagging schema.
+  No packet is spawned by this ADR.
+- **Resolution (2026-07-22, Mikael, direct implementation-time scope
+  decision, P1-2):** Deferred. The basic similarity-band heuristic ships in
+  P1-2; version-aware resolution is not built. Tracked as OI-07's
+  continuing disposition in `decisions.md`.

--- a/docs/adr/ADR-0013-oi-08-fact-retirement-archival-deferred.md
+++ b/docs/adr/ADR-0013-oi-08-fact-retirement-archival-deferred.md
@@ -1,0 +1,67 @@
+# ADR-0013: OI-08 (fact retirement/archival) deferred beyond P1-2
+
+- **Status:** accepted
+- **Type:** design
+- **Decision:** Defer fact retirement/archival beyond P1-2. This packet
+  ships only the read-side half of OI-08's temporal-validity scope —
+  `ITrustEvaluator.Evaluate` flags facts missing `ValidFrom` when a
+  domain's policy sets `TemporalValidityRequired` — and builds none of
+  `retired_at`, `retired_reason`, a query-time "exclude retired" filter, an
+  "include historical" flag, or a retention policy.
+- **Why:**
+  - OI-08 (`decisions.md`) already framed this precisely: "design needed:
+    retired_at timestamp, retired_reason field, query-time filter excluding
+    retired facts by default, explicit 'include historical' flag, and a
+    retention policy," with revisit trigger "...or P1-2 (temporal validity)
+    is being implemented" — that trigger is this packet.
+  - P1-2's brief acceptance criterion was "facts filtered/flagged by
+    valid_from/valid_until." Investigation during implementation found
+    `ITrustScoringService.Score` (`src/Deke.Infrastructure/Trust/
+    TrustScoringService.cs`) — a pre-existing, separate mechanism from the
+    `trust_state` classifier this packet adds — already zeroes a fact's
+    composite trust score when `now` falls outside `[validFrom,
+    validUntil]`. It is wired into `FederatedSearchService.MergeResults`
+    (federated result ranking) and `KnowledgeDepth.Compute` (advisory-
+    pipeline model routing), so `valid_until` expiry already demotes
+    affected facts out of practical relevance at query time. Only the
+    `valid_from`-missing half of temporal validity had no producer —
+    nothing set or checked it — which is the gap `ITrustEvaluator`'s
+    `TemporalValidityRequired` gate closes.
+  - Building `retired_at`/`retired_reason`/historical-inclusion machinery
+    now would answer a broader question ("what happens to a fact after it
+    is retired, and how do we preserve the historical record for
+    pattern-evolution and legacy-system queries") that OI-08 explicitly
+    scopes as its own structural feature, separate from the
+    temporal-validity read-side check P1-2 was sized for.
+  - No facts have been retired in practice yet (OI-08's own deferral
+    rationale), so there is no live pressure to design the retention policy
+    now.
+- **Rejected alternatives:**
+  - Build `retired_at`/`retired_reason` plus query-time filtering now,
+    since the packet was already touching trust/temporal code — rejected:
+    OI-08 is a structural feature (schema + filter semantics + retention
+    policy design), not a small extension of this packet's scope;
+    conflating it here risks an under-designed retirement model shipped as
+    a side effect.
+  - Treat "facts filtered/flagged by valid_from/valid_until" as requiring
+    new `valid_until`-expiry code in `ITrustEvaluator` — rejected:
+    `ITrustScoringService` already does this at search-ranking time;
+    duplicating it in the `trust_state` classifier would create two
+    independent, potentially divergent expiry mechanisms for the same two
+    columns.
+  - Leave `valid_from`-missing facts unflagged (do nothing for OI-08 in
+    this packet) — rejected: the brief's acceptance criterion explicitly
+    covers `valid_from`, and `TemporalValidityRequired` was cheap to add
+    alongside the other policy gates.
+- **Consequences:** OI-08 remains open in `decisions.md`'s Open Design
+  Questions, with its revisit trigger narrowed going forward to: the first
+  domain's facts beginning to approach their `valid_until` dates in
+  practice. No packet is spawned by this ADR. Future readers should note
+  the two distinct trust mechanisms this packet leaves in place —
+  `ITrustScoringService` (numeric, search-ranking, handles `valid_until`)
+  and `ITrustEvaluator` (categorical `trust_state`, handles missing
+  `valid_from`) — are both intentional, not duplicative drift.
+- **Resolution (2026-07-22, Mikael, direct implementation-time scope
+  decision, P1-2):** Deferred. Temporal-validity read-side flagging
+  (missing `valid_from`) ships in P1-2; retirement/archival machinery is
+  not built. Tracked as OI-08's continuing disposition in `decisions.md`.

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -145,6 +145,30 @@ already-stored facts is separate follow-up work.
 
 Merged to main via PR #31. See [ROADMAP.md](../ROADMAP.md) R2 for closure status.
 
+### 2026-07-22 P1-2 Quality Pipeline Activation
+
+P1-2 activates the P1-1 trust schema into working behavior: `ITrustEvaluator`
+classifies `Unscored` facts to `Accepted`/`Flagged` per `domain_trust_policy`,
+`TrustStateEvaluationService` and `ContradictionDetectionService` run the
+classification and basic contradiction-detection cycles, and `GET
+/api/review-queue` plus `GET`/`PUT /api/domains/{domain}/trust-policy` close
+the P1-1 gap where the trust-policy repository shipped with no endpoints
+wired to it. OI-07 (version-aware contradiction resolution) and OI-08 (fact
+retirement/archival) were reviewed as scheduled and dispositioned as
+deferred -- see [ADR-0012](../adr/ADR-0012-oi-07-version-aware-contradiction-deferred.md)
+and [ADR-0013](../adr/ADR-0013-oi-08-fact-retirement-archival-deferred.md)
+for the reasoning and each item's narrowed revisit trigger.
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-07-22 | Fail open to `Accepted` when a domain has no configured `domain_trust_policy`, rather than leaving facts stuck at `Unscored` | Matches today's de-facto no-gating reality (zero domains have a seeded policy yet) and top-level CLAUDE.md's zero-config domain philosophy ("just start adding facts... no pre-configuration needed"). A fact stuck at `Unscored` forever would never resolve into a state the rest of the pipeline can act on, silently excluding every fact in every domain from the review queue's `Flagged`/`Contested` filter until an operator configures a policy nobody yet knows they need. |
+
+Verified: build green, 115/115 tests passing. `init.sql`'s new partial index
+(`idx_facts_trust_state`) is not yet applied to the live `deke-postgres`
+container -- pending, tracked as a follow-up step, same class of gap as
+P1-1's `interaction_logs` discovery above. See [ROADMAP.md](../ROADMAP.md)
+P1-2 for closure status.
+
 ---
 
 ## Guardrails and Risk Analysis
@@ -400,3 +424,11 @@ Precise trigger conditions:
 | After 50+ user interactions on a single domain | OI-06 (Social Proof), OI-05 (Debate-and-Critique) |
 | Before any high-stakes domain activation | OI-09 (Curator Workflow) -- mandatory |
 | When second external consumer requests integration | OI-10 (A2A Trigger Conditions) |
+
+> **2026-07-22 review ([ADR-0012](../adr/ADR-0012-oi-07-version-aware-contradiction-deferred.md)
+> and [ADR-0013](../adr/ADR-0013-oi-08-fact-retirement-archival-deferred.md), both accepted):**
+> OI-07 (Version-Aware Contradiction) and OI-08 (Fact Retirement) were reviewed as scheduled,
+> during P1-2 implementation. Both are dispositioned as deferred -- see the two ADRs for the
+> reasoning and each item's narrowed revisit trigger. The "After P1-2 (Quality Pipeline)" row
+> above is retained as the historical record of what was scheduled; both its items are now
+> resolved.

--- a/docs/architecture/specification.md
+++ b/docs/architecture/specification.md
@@ -123,7 +123,7 @@ The atomic unit of knowledge. A single claim with provenance metadata.
 | contradiction_flag | BOOLEAN | Another fact with opposing polarity exists (default FALSE) |
 | trust_state | VARCHAR(20) | Unscored, Accepted, Flagged, Contested, Rejected (default Unscored) |
 
-Indexes: IVFFlat on embedding (cosine ops, lists=100), domain, source_id, created_at DESC, composite (domain, is_outdated).
+Indexes: IVFFlat on embedding (cosine ops, lists=100), domain, source_id, created_at DESC, composite (domain, is_outdated), partial (domain, trust_state) WHERE trust_state <> 'Accepted' (serves the review-queue and pending-evaluation/contradiction-scan queries).
 
 #### terms
 
@@ -323,6 +323,10 @@ Immutable change-history snapshot of a fact. Maps to the `fact_version` table. `
 
 Per-domain configuration governing how strictly provenance is enforced. Maps to the `domain_trust_policy` table, keyed by `domain` (no surrogate id) -- `IDomainTrustPolicyRepository` exposes `UpsertAsync` rather than separate insert/update.
 
+### ITrustEvaluator
+
+Classifies a fact's `TrustState` (`Deke.Core.Interfaces`; implemented by `TrustEvaluator` in `Deke.Infrastructure.Trust`). Pure and synchronous -- no I/O. `Evaluate(Fact, SourceTier?, DomainTrustPolicy?)` fails open to `Accepted` when the domain has no configured policy; otherwise checks `RequirePrimarySource`, `TemporalValidityRequired` (flags facts missing `ValidFrom`), `MinConfidenceScore`, `MinCorroboration`, and `FlagForReviewTiers`, returning `Flagged` on the first gate that fails. Distinct from `ITrustScoringService`, the pre-existing numeric search-ranking multiplier that already handles `valid_until` expiry at query time -- see [decisions.md](decisions.md) (OI-08 disposition, ADR-0013) for how the two mechanisms divide responsibility. Driven by `TrustStateEvaluationService` (`Deke.Worker`), which classifies `Unscored` facts per domain on a timed cycle.
+
 ### FederationPeer
 
 A known DEKE instance. Maps to the `federation_peers` table.
@@ -377,6 +381,14 @@ Federation headers (inbound): `X-Federation-Request-Id`, `X-Federation-Visited`,
 | POST | `/api/federation/peers` | Register a new peer (requires API key) |
 | DELETE | `/api/federation/peers/{id}` | Remove a peer |
 
+### Trust and Review Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/review-queue` | Facts pending human review (`trust_state` `Flagged` or `Contested`). Accepts domain filter and limit (clamped 1-500, default 100). |
+| GET | `/api/domains/{domain}/trust-policy` | Get a domain's trust policy configuration. Returns 404 if unconfigured. |
+| PUT | `/api/domains/{domain}/trust-policy` | Create or replace a domain's trust policy configuration (requires API key) |
+
 ### Planned Endpoints
 
 | Method | Path | Package | Description |
@@ -386,9 +398,6 @@ Federation headers (inbound): `X-Federation-Request-Id`, `X-Federation-Visited`,
 | POST | `/api/feedback` | EE | Submit explicit feedback for an interaction |
 | GET | `/api/interactions` | EE | Query interaction log |
 | GET | `/api/health/domain/{domain}` | EE | Domain evolution health report |
-| GET | `/api/domains/{domain}/trust-policy` | P1-1 | Domain trust policy configuration |
-| PUT | `/api/domains/{domain}/trust-policy` | P1-1 | Update trust policy |
-| GET | `/api/review-queue` | P1-2 | Facts pending human review |
 
 ---
 

--- a/init.sql
+++ b/init.sql
@@ -78,6 +78,8 @@ CREATE INDEX idx_facts_content_hash ON facts(content_hash);
 CREATE UNIQUE INDEX idx_facts_domain_normhash ON facts(domain, normalized_hash);
 -- R2 dedup: async level-4 candidate scan (facts without a similarity hash yet)
 CREATE INDEX idx_facts_pending_simhash ON facts(id) WHERE similarity_hash IS NULL;
+-- P1-2 quality pipeline: review-queue selection and pending-evaluation/contradiction scans
+CREATE INDEX idx_facts_trust_state ON facts(domain, trust_state) WHERE trust_state <> 'Accepted';
 
 -- Terms: Domain-specific terminology
 CREATE TABLE terms (

--- a/src/Deke.Api/Endpoints/DomainTrustPolicyEndpoints.cs
+++ b/src/Deke.Api/Endpoints/DomainTrustPolicyEndpoints.cs
@@ -1,0 +1,60 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+
+namespace Deke.Api.Endpoints;
+
+public static class DomainTrustPolicyEndpoints
+{
+    public static void MapDomainTrustPolicyEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/domains").WithTags("DomainTrustPolicy");
+
+        group.MapGet("/{domain}/trust-policy", GetTrustPolicy)
+            .WithName("GetTrustPolicy")
+            .WithDescription("Get a domain's trust policy configuration")
+            .AllowAnonymous();
+
+        group.MapPut("/{domain}/trust-policy", UpdateTrustPolicy)
+            .WithName("UpdateTrustPolicy")
+            .WithDescription("Create or replace a domain's trust policy configuration")
+            .RequireAuthorization();
+    }
+
+    internal static async Task<IResult> GetTrustPolicy(
+        string domain,
+        IDomainTrustPolicyRepository policyRepo,
+        CancellationToken ct)
+    {
+        var policy = await policyRepo.GetByDomainAsync(domain, ct);
+        return policy is null ? Results.NotFound() : Results.Ok(policy);
+    }
+
+    internal static async Task<IResult> UpdateTrustPolicy(
+        string domain,
+        UpdateTrustPolicyRequest request,
+        IDomainTrustPolicyRepository policyRepo,
+        CancellationToken ct)
+    {
+        var policy = new DomainTrustPolicy
+        {
+            Domain = domain,
+            RequirePrimarySource = request.RequirePrimarySource,
+            MinCorroboration = request.MinCorroboration,
+            AutoAcceptTiers = request.AutoAcceptTiers,
+            FlagForReviewTiers = request.FlagForReviewTiers,
+            TemporalValidityRequired = request.TemporalValidityRequired,
+            MinConfidenceScore = request.MinConfidenceScore
+        };
+
+        await policyRepo.UpsertAsync(policy, ct);
+        return Results.Ok(policy);
+    }
+}
+
+public record UpdateTrustPolicyRequest(
+    bool RequirePrimarySource,
+    int MinCorroboration,
+    List<SourceTier> AutoAcceptTiers,
+    List<SourceTier> FlagForReviewTiers,
+    bool TemporalValidityRequired,
+    float MinConfidenceScore);

--- a/src/Deke.Api/Endpoints/ReviewQueueEndpoints.cs
+++ b/src/Deke.Api/Endpoints/ReviewQueueEndpoints.cs
@@ -1,0 +1,28 @@
+﻿using Deke.Core.Interfaces;
+
+namespace Deke.Api.Endpoints;
+
+public static class ReviewQueueEndpoints
+{
+    public static void MapReviewQueueEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/review-queue").WithTags("ReviewQueue");
+
+        group.MapGet("/", GetReviewQueue)
+            .WithName("GetReviewQueue")
+            .WithDescription("Get facts pending human review")
+            .AllowAnonymous();
+    }
+
+    internal static async Task<IResult> GetReviewQueue(
+        string? domain,
+        int limit = 100,
+        IFactRepository factRepo = null!,
+        CancellationToken ct = default)
+    {
+        limit = Math.Clamp(limit, 1, 500);
+
+        var facts = await factRepo.GetPendingReviewAsync(domain, limit, ct);
+        return Results.Ok(facts);
+    }
+}

--- a/src/Deke.Api/Program.cs
+++ b/src/Deke.Api/Program.cs
@@ -56,5 +56,7 @@ app.MapSearchEndpoints();
 app.MapFactEndpoints();
 app.MapSourceEndpoints();
 app.MapFederationEndpoints();
+app.MapReviewQueueEndpoints();
+app.MapDomainTrustPolicyEndpoints();
 
 app.Run();

--- a/src/Deke.Core/Interfaces/IFactRepository.cs
+++ b/src/Deke.Core/Interfaces/IFactRepository.cs
@@ -13,6 +13,7 @@ public interface IFactRepository
         string? domain,
         int limit = 10,
         float minSimilarity = 0.5f,
+        float? maxSimilarity = null,
         CancellationToken ct = default);
 
     Task<Guid> AddAsync(Fact fact, CancellationToken ct = default);
@@ -27,6 +28,13 @@ public interface IFactRepository
     Task SetSimilarityHashAsync(Guid id, long similarityHash, CancellationToken ct = default);
     Task<List<Fact>> GetPendingSimilarityAsync(int limit, CancellationToken ct = default);
     Task<List<Fact>> GetPendingSemanticAsync(int limit, CancellationToken ct = default);
+
+    // Quality pipeline (P1-2)
+    Task<List<Fact>> GetPendingTrustEvaluationAsync(int limit, CancellationToken ct = default);
+    Task SetTrustStateAsync(Guid id, TrustState state, CancellationToken ct = default);
+    Task<List<Fact>> GetContradictionScanCandidatesAsync(int limit, CancellationToken ct = default);
+    Task MarkContradictedAsync(Guid id, CancellationToken ct = default);
+    Task<List<Fact>> GetPendingReviewAsync(string? domain, int limit, CancellationToken ct = default);
 
     Task<int> GetCountAsync(string domain, CancellationToken ct = default);
     Task<List<Fact>> GetRecentAsync(string domain, int days, int limit = 100, CancellationToken ct = default);

--- a/src/Deke.Core/Interfaces/ITrustEvaluator.cs
+++ b/src/Deke.Core/Interfaces/ITrustEvaluator.cs
@@ -1,0 +1,8 @@
+﻿using Deke.Core.Models;
+
+namespace Deke.Core.Interfaces;
+
+public interface ITrustEvaluator
+{
+    TrustState Evaluate(Fact fact, SourceTier? sourceTier, DomainTrustPolicy? policy);
+}

--- a/src/Deke.Core/Models/Source.cs
+++ b/src/Deke.Core/Models/Source.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Deke.Core.Models;
 
@@ -38,6 +39,7 @@ public enum SourceType
     File
 }
 
+[JsonConverter(typeof(JsonStringEnumConverter<SourceTier>))]
 public enum SourceTier
 {
     Primary,

--- a/src/Deke.Infrastructure/Advisory/AdvisoryPipeline.cs
+++ b/src/Deke.Infrastructure/Advisory/AdvisoryPipeline.cs
@@ -64,7 +64,7 @@ public class AdvisoryPipeline : IAdvisoryPipeline
 
         // Stage 2 — fact retrieval (local-only, trust-filtered).
         var embedding = _embeddings.GenerateEmbedding(request.Query);
-        var results = await _facts.SearchAsync(embedding, request.Domain, _config.RetrievalLimit, _config.MinSimilarity, ct);
+        var results = await _facts.SearchAsync(embedding, request.Domain, _config.RetrievalLimit, _config.MinSimilarity, ct: ct);
 
         if (results.Count == 0)
         {

--- a/src/Deke.Infrastructure/Federation/FederatedSearchService.cs
+++ b/src/Deke.Infrastructure/Federation/FederatedSearchService.cs
@@ -56,7 +56,7 @@ public class FederatedSearchService : IFederatedSearchService
 
         // 1. Generate embedding and run local search
         var embedding = _embeddings.GenerateEmbedding(request.Query);
-        var localResults = await _factRepo.SearchAsync(embedding, request.Domain, limit, minSimilarity, ct);
+        var localResults = await _factRepo.SearchAsync(embedding, request.Domain, limit, minSimilarity, ct: ct);
 
         // 2. Determine if federation is needed
         var federatedResults = new List<(FactSearchResult Result, string PeerInstanceId, int Hops)>();

--- a/src/Deke.Infrastructure/Ingestion/ContradictionDetectionConfig.cs
+++ b/src/Deke.Infrastructure/Ingestion/ContradictionDetectionConfig.cs
@@ -1,0 +1,20 @@
+﻿namespace Deke.Infrastructure.Ingestion;
+
+/// <summary>
+/// Tunables for the contradiction-detection job. Bound from the
+/// "ContradictionDetection" configuration section.
+/// </summary>
+public class ContradictionDetectionConfig
+{
+    /// <summary>Interval between contradiction-detection job cycles.</summary>
+    public int IntervalMinutes { get; set; } = 45;
+
+    /// <summary>Facts processed per job cycle.</summary>
+    public int BatchSize { get; set; } = 200;
+
+    /// <summary>Lower bound of the candidate similarity band (below L5's dedup threshold).</summary>
+    public float MinSimilarity { get; set; } = 0.75f;
+
+    /// <summary>Upper bound of the candidate similarity band.</summary>
+    public float MaxSimilarity { get; set; } = 0.90f;
+}

--- a/src/Deke.Infrastructure/Ingestion/TrustEvaluationConfig.cs
+++ b/src/Deke.Infrastructure/Ingestion/TrustEvaluationConfig.cs
@@ -1,0 +1,14 @@
+﻿namespace Deke.Infrastructure.Ingestion;
+
+/// <summary>
+/// Tunables for the trust-state evaluation job. Bound from the
+/// "TrustEvaluation" configuration section.
+/// </summary>
+public class TrustEvaluationConfig
+{
+    /// <summary>Interval between evaluation job cycles.</summary>
+    public int IntervalMinutes { get; set; } = 20;
+
+    /// <summary>Facts processed per job cycle.</summary>
+    public int BatchSize { get; set; } = 200;
+}

--- a/src/Deke.Infrastructure/Repositories/FactRepository.cs
+++ b/src/Deke.Infrastructure/Repositories/FactRepository.cs
@@ -54,6 +54,7 @@ public class FactRepository : IFactRepository
         string? domain,
         int limit = 10,
         float minSimilarity = 0.5f,
+        float? maxSimilarity = null,
         CancellationToken ct = default)
     {
         await using var conn = await _db.CreateConnectionAsync(ct);
@@ -73,10 +74,11 @@ public class FactRepository : IFactRepository
             WHERE f.embedding IS NOT NULL
               {domainClause}
               AND 1 - (f.embedding <=> @vector::vector) > @minSimilarity
+              AND (@maxSimilarity IS NULL OR 1 - (f.embedding <=> @vector::vector) <= @maxSimilarity)
             ORDER BY f.embedding <=> @vector::vector
             LIMIT @limit
             """,
-            new { vector, domain, minSimilarity, limit });
+            new { vector, domain, minSimilarity, maxSimilarity, limit });
         return results.AsList();
     }
 
@@ -340,6 +342,82 @@ public class FactRepository : IFactRepository
             LIMIT @limit
             """,
             new { limit });
+        return results.AsList();
+    }
+
+    // Quality pipeline (P1-2)
+
+    public async Task<List<Fact>> GetPendingTrustEvaluationAsync(int limit, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        var results = await conn.QueryAsync<Fact>(
+            $"""
+            SELECT {SelectColumnsNoEmbedding} FROM facts
+            WHERE trust_state = 'Unscored'
+              AND duplicate_of IS NULL
+              AND is_outdated = FALSE
+            ORDER BY created_at
+            LIMIT @limit
+            """,
+            new { limit });
+        return results.AsList();
+    }
+
+    public async Task SetTrustStateAsync(Guid id, TrustState state, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        await conn.ExecuteAsync(
+            "UPDATE facts SET trust_state = @state, updated_at = @now WHERE id = @id",
+            new { id, state, now = DateTimeOffset.UtcNow });
+    }
+
+    public async Task<List<Fact>> GetContradictionScanCandidatesAsync(int limit, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        var results = await conn.QueryAsync<Fact>(
+            $"""
+            SELECT {SelectAllColumns} FROM facts
+            WHERE trust_state IN ('Accepted', 'Flagged')
+              AND NOT contradiction_flag
+              AND embedding IS NOT NULL
+              AND duplicate_of IS NULL
+              AND is_outdated = FALSE
+            ORDER BY created_at
+            LIMIT @limit
+            """,
+            new { limit });
+        return results.AsList();
+    }
+
+    public async Task MarkContradictedAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        await conn.ExecuteAsync(
+            """
+            UPDATE facts
+            SET contradiction_flag = TRUE,
+                trust_state = CASE WHEN trust_state <> 'Rejected' THEN 'Contested' ELSE trust_state END,
+                updated_at = @now
+            WHERE id = @id
+            """,
+            new { id, now = DateTimeOffset.UtcNow });
+    }
+
+    public async Task<List<Fact>> GetPendingReviewAsync(string? domain, int limit, CancellationToken ct = default)
+    {
+        await using var conn = await _db.CreateConnectionAsync(ct);
+        var domainClause = domain is not null ? "AND domain = @domain" : "";
+        var results = await conn.QueryAsync<Fact>(
+            $"""
+            SELECT {SelectColumnsNoEmbedding} FROM facts
+            WHERE trust_state IN ('Flagged', 'Contested')
+              {domainClause}
+              AND duplicate_of IS NULL
+              AND is_outdated = FALSE
+            ORDER BY created_at DESC
+            LIMIT @limit
+            """,
+            new { domain, limit });
         return results.AsList();
     }
 }

--- a/src/Deke.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Deke.Infrastructure/ServiceCollectionExtensions.cs
@@ -72,6 +72,17 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    public static IServiceCollection AddDekeQualityPipeline(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<TrustEvaluationConfig>(configuration.GetSection("TrustEvaluation"));
+        services.Configure<ContradictionDetectionConfig>(configuration.GetSection("ContradictionDetection"));
+
+        services.AddScoped<ITrustEvaluator, TrustEvaluator>();
+
+        return services;
+    }
+
     public static IServiceCollection AddDekeHarvesters(this IServiceCollection services)
     {
         services.AddHttpClient();

--- a/src/Deke.Infrastructure/Trust/TrustEvaluator.cs
+++ b/src/Deke.Infrastructure/Trust/TrustEvaluator.cs
@@ -1,0 +1,30 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+
+namespace Deke.Infrastructure.Trust;
+
+public class TrustEvaluator : ITrustEvaluator
+{
+    public TrustState Evaluate(Fact fact, SourceTier? sourceTier, DomainTrustPolicy? policy)
+    {
+        if (policy is null)
+            return TrustState.Accepted;
+
+        if (policy.RequirePrimarySource && sourceTier != SourceTier.Primary)
+            return TrustState.Flagged;
+
+        if (policy.TemporalValidityRequired && fact.ValidFrom is null)
+            return TrustState.Flagged;
+
+        if (fact.Confidence < policy.MinConfidenceScore)
+            return TrustState.Flagged;
+
+        if (policy.MinCorroboration > 0 && fact.CorroborationCount < policy.MinCorroboration)
+            return TrustState.Flagged;
+
+        if (sourceTier is not null && policy.FlagForReviewTiers.Contains(sourceTier.Value))
+            return TrustState.Flagged;
+
+        return TrustState.Accepted;
+    }
+}

--- a/src/Deke.Worker/Program.cs
+++ b/src/Deke.Worker/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddDekeEmbeddings(builder.Configuration);
 builder.Services.AddDekeHarvesters();
 builder.Services.AddDekeDedup(builder.Configuration);
 builder.Services.AddDekeFederation(builder.Configuration);
+builder.Services.AddDekeQualityPipeline(builder.Configuration);
 
 // PatternDiscoveryService summarizes fact clusters via the same keyed IChatClient
 // backends the Advisory pipeline uses (ollama key -- local/cheap, matches its
@@ -47,6 +48,8 @@ builder.Services.AddHostedService<LearningCycleService>();
 builder.Services.AddHostedService<PeerHealthCheckService>();
 builder.Services.AddHostedService<SimilarityDedupService>();
 builder.Services.AddHostedService<SemanticDedupService>();
+builder.Services.AddHostedService<TrustStateEvaluationService>();
+builder.Services.AddHostedService<ContradictionDetectionService>();
 
 var host = builder.Build();
 host.Run();

--- a/src/Deke.Worker/Services/ContradictionDetectionService.cs
+++ b/src/Deke.Worker/Services/ContradictionDetectionService.cs
@@ -1,0 +1,120 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+using Deke.Infrastructure.Ingestion;
+using Microsoft.Extensions.Options;
+
+namespace Deke.Worker.Services;
+
+/// <summary>
+/// Quality pipeline (P1-2): flags facts with opposing evidence using a basic,
+/// non-version-aware embedding-similarity heuristic (candidate band below L5's
+/// dedup threshold). Version-aware resolution is deferred -- see OI-07 in
+/// decisions.md.
+/// </summary>
+public class ContradictionDetectionService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<ContradictionDetectionService> _logger;
+    private readonly ContradictionDetectionConfig _config;
+
+    public ContradictionDetectionService(
+        IServiceProvider serviceProvider,
+        ILogger<ContradictionDetectionService> logger,
+        IOptions<ContradictionDetectionConfig> config)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+        _config = config.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("ContradictionDetectionService started");
+        var interval = TimeSpan.FromMinutes(_config.IntervalMinutes);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RunCycleAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in contradiction detection cycle");
+            }
+
+            await Task.Delay(interval, stoppingToken);
+        }
+    }
+
+    internal async Task RunCycleAsync(CancellationToken ct)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var factRepo = scope.ServiceProvider.GetRequiredService<IFactRepository>();
+        var relationRepo = scope.ServiceProvider.GetRequiredService<IFactRelationRepository>();
+        var learningLogRepo = scope.ServiceProvider.GetRequiredService<ILearningLogRepository>();
+
+        var pending = await factRepo.GetContradictionScanCandidatesAsync(_config.BatchSize, ct);
+        if (pending.Count == 0)
+            return;
+
+        foreach (var domainGroup in pending.GroupBy(f => f.Domain))
+        {
+            var domain = domainGroup.Key;
+            var log = new LearningLog
+            {
+                Domain = domain,
+                CycleType = "contradiction-detection",
+                StartedAt = DateTimeOffset.UtcNow
+            };
+
+            try
+            {
+                var flagged = 0;
+                foreach (var fact in domainGroup)
+                {
+                    if (fact.Embedding is null)
+                        continue;
+
+                    var candidates = await factRepo.SearchAsync(
+                        fact.Embedding, fact.Domain, limit: 5,
+                        minSimilarity: _config.MinSimilarity, maxSimilarity: _config.MaxSimilarity, ct: ct);
+
+                    foreach (var candidate in candidates.Where(c => c.Id != fact.Id))
+                    {
+                        var alreadyLinked = await relationRepo.ExistsAsync(fact.Id, candidate.Id, "contradicts", ct)
+                            || await relationRepo.ExistsAsync(candidate.Id, fact.Id, "contradicts", ct);
+                        if (alreadyLinked)
+                            continue;
+
+                        await relationRepo.AddAsync(new FactRelation
+                        {
+                            FromFactId = fact.Id,
+                            ToFactId = candidate.Id,
+                            RelationType = "contradicts"
+                        }, ct);
+                        await factRepo.MarkContradictedAsync(fact.Id, ct);
+                        await factRepo.MarkContradictedAsync(candidate.Id, ct);
+                        flagged++;
+                    }
+                }
+
+                log.FactsUpdated = flagged;
+                log.CompletedAt = DateTimeOffset.UtcNow;
+                log.Notes = $"Scanned {domainGroup.Count()} facts, flagged {flagged} contradicting pairs";
+            }
+            catch (Exception ex)
+            {
+                log.ErrorMessage = ex.Message;
+                log.CompletedAt = DateTimeOffset.UtcNow;
+                _logger.LogError(ex, "Error detecting contradictions for domain {Domain}", domain);
+            }
+
+            await learningLogRepo.AddAsync(log, ct);
+        }
+    }
+}

--- a/src/Deke.Worker/Services/TrustStateEvaluationService.cs
+++ b/src/Deke.Worker/Services/TrustStateEvaluationService.cs
@@ -1,0 +1,114 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+using Deke.Infrastructure.Ingestion;
+using Microsoft.Extensions.Options;
+
+namespace Deke.Worker.Services;
+
+/// <summary>
+/// Quality pipeline (P1-2): classifies Unscored facts into Accepted or Flagged
+/// per the fact's domain trust policy. Domains without a configured policy
+/// fail open (Accepted) -- see ADR discussion in decisions.md.
+/// </summary>
+public class TrustStateEvaluationService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<TrustStateEvaluationService> _logger;
+    private readonly TrustEvaluationConfig _config;
+
+    public TrustStateEvaluationService(
+        IServiceProvider serviceProvider,
+        ILogger<TrustStateEvaluationService> logger,
+        IOptions<TrustEvaluationConfig> config)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+        _config = config.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("TrustStateEvaluationService started");
+        var interval = TimeSpan.FromMinutes(_config.IntervalMinutes);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RunCycleAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in trust evaluation cycle");
+            }
+
+            await Task.Delay(interval, stoppingToken);
+        }
+    }
+
+    internal async Task RunCycleAsync(CancellationToken ct)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var factRepo = scope.ServiceProvider.GetRequiredService<IFactRepository>();
+        var sourceRepo = scope.ServiceProvider.GetRequiredService<ISourceRepository>();
+        var policyRepo = scope.ServiceProvider.GetRequiredService<IDomainTrustPolicyRepository>();
+        var evaluator = scope.ServiceProvider.GetRequiredService<ITrustEvaluator>();
+        var learningLogRepo = scope.ServiceProvider.GetRequiredService<ILearningLogRepository>();
+
+        var pending = await factRepo.GetPendingTrustEvaluationAsync(_config.BatchSize, ct);
+        if (pending.Count == 0)
+            return;
+
+        foreach (var domainGroup in pending.GroupBy(f => f.Domain))
+        {
+            var domain = domainGroup.Key;
+            var log = new LearningLog
+            {
+                Domain = domain,
+                CycleType = "trust-evaluation",
+                StartedAt = DateTimeOffset.UtcNow
+            };
+
+            try
+            {
+                var policy = await policyRepo.GetByDomainAsync(domain, ct);
+
+                var accepted = 0;
+                var flagged = 0;
+                foreach (var fact in domainGroup)
+                {
+                    SourceTier? tier = null;
+                    if (fact.SourceId is Guid sourceId)
+                    {
+                        var source = await sourceRepo.GetByIdAsync(sourceId, ct);
+                        tier = source?.SourceTier;
+                    }
+
+                    var newState = evaluator.Evaluate(fact, tier, policy);
+                    await factRepo.SetTrustStateAsync(fact.Id, newState, ct);
+
+                    if (newState == TrustState.Accepted)
+                        accepted++;
+                    else
+                        flagged++;
+                }
+
+                log.FactsUpdated = accepted + flagged;
+                log.CompletedAt = DateTimeOffset.UtcNow;
+                log.Notes = $"Evaluated {domainGroup.Count()} facts: {accepted} accepted, {flagged} flagged";
+            }
+            catch (Exception ex)
+            {
+                log.ErrorMessage = ex.Message;
+                log.CompletedAt = DateTimeOffset.UtcNow;
+                _logger.LogError(ex, "Error evaluating trust state for domain {Domain}", domain);
+            }
+
+            await learningLogRepo.AddAsync(log, ct);
+        }
+    }
+}

--- a/tests/Deke.Tests/AdvisoryPipelineTests.cs
+++ b/tests/Deke.Tests/AdvisoryPipelineTests.cs
@@ -173,7 +173,8 @@ public class AdvisoryPipelineTests
     private sealed class FakeFactRepository(List<FactSearchResult> results) : IFactRepository
     {
         public Task<List<FactSearchResult>> SearchAsync(
-            float[] embedding, string? domain, int limit = 10, float minSimilarity = 0.5f, CancellationToken ct = default)
+            float[] embedding, string? domain, int limit = 10, float minSimilarity = 0.5f,
+            float? maxSimilarity = null, CancellationToken ct = default)
             => Task.FromResult(results);
 
         public Task<Fact?> GetByIdAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
@@ -185,6 +186,11 @@ public class AdvisoryPipelineTests
         public Task<int> GetCountAsync(string domain, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetRecentAsync(string domain, int days, int limit = 100, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetWithoutRelationsAsync(string domain, int limit = 50, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingTrustEvaluationAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task SetTrustStateAsync(Guid id, TrustState state, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetContradictionScanCandidatesAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task MarkContradictedAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingReviewAsync(string? domain, int limit, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<DomainStats>> GetDomainStatsAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<Fact?> GetByContentHashAsync(string contentHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<Fact?> GetByNormalizedHashAsync(string normalizedHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/Deke.Tests/ApiEndpointTests.cs
+++ b/tests/Deke.Tests/ApiEndpointTests.cs
@@ -279,10 +279,15 @@ public class ApiEndpointTests
         public Task<Guid> AddAsync(Fact fact, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetByDomainAsync(string domain, int limit = 100, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetBySourceAsync(Guid sourceId, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<List<FactSearchResult>> SearchAsync(float[] embedding, string? domain, int limit = 10, float minSimilarity = 0.5f, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<FactSearchResult>> SearchAsync(float[] embedding, string? domain, int limit = 10, float minSimilarity = 0.5f, float? maxSimilarity = null, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<int> GetCountAsync(string domain, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetRecentAsync(string domain, int days, int limit = 100, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetWithoutRelationsAsync(string domain, int limit = 50, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingTrustEvaluationAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task SetTrustStateAsync(Guid id, TrustState state, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetContradictionScanCandidatesAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task MarkContradictedAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingReviewAsync(string? domain, int limit, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<DomainStats>> GetDomainStatsAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<Fact?> GetByContentHashAsync(string contentHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<Fact?> GetByNormalizedHashAsync(string normalizedHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/Deke.Tests/ApiEndpointTests.cs
+++ b/tests/Deke.Tests/ApiEndpointTests.cs
@@ -1,6 +1,7 @@
 ﻿using Deke.Api.Endpoints;
 using Deke.Core.Interfaces;
 using Deke.Core.Models;
+using Deke.Tests.Fakes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
@@ -421,22 +422,5 @@ public class ApiEndpointTests
         public Task<List<Source>> GetAllAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task DeactivateAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
         public Task DeleteAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
-    }
-
-    private sealed class FakeDomainTrustPolicyRepository : IDomainTrustPolicyRepository
-    {
-        private readonly Dictionary<string, DomainTrustPolicy> _policies = new();
-
-        public Task<DomainTrustPolicy?> GetByDomainAsync(string domain, CancellationToken ct = default)
-            => Task.FromResult(_policies.GetValueOrDefault(domain));
-
-        public Task<List<DomainTrustPolicy>> GetAllAsync(CancellationToken ct = default)
-            => Task.FromResult(_policies.Values.ToList());
-
-        public Task UpsertAsync(DomainTrustPolicy policy, CancellationToken ct = default)
-        {
-            _policies[policy.Domain] = policy;
-            return Task.CompletedTask;
-        }
     }
 }

--- a/tests/Deke.Tests/ApiEndpointTests.cs
+++ b/tests/Deke.Tests/ApiEndpointTests.cs
@@ -213,6 +213,89 @@ public class ApiEndpointTests
         Assert.Equal(TimeSpan.FromHours(6), ok.Value.CheckInterval);
     }
 
+    // ---- GET /api/review-queue ----
+
+    [Fact]
+    public async Task GetReviewQueue_ReturnsOnlyFlaggedAndContestedFacts()
+    {
+        var flagged = NewFact("flagged content");
+        flagged.TrustState = TrustState.Flagged;
+        var contested = NewFact("contested content");
+        contested.TrustState = TrustState.Contested;
+        var accepted = NewFact("accepted content");
+        accepted.TrustState = TrustState.Accepted;
+        var repo = new FakeFactRepository(flagged, contested, accepted);
+
+        var result = await ReviewQueueEndpoints.GetReviewQueue(null, 100, repo, CancellationToken.None);
+
+        var ok = Assert.IsType<Ok<List<Fact>>>(result);
+        Assert.Equal(2, ok.Value!.Count);
+        Assert.Contains(ok.Value, f => f.Id == flagged.Id);
+        Assert.Contains(ok.Value, f => f.Id == contested.Id);
+    }
+
+    [Fact]
+    public async Task GetReviewQueue_FiltersByDomain()
+    {
+        var fishing = NewFact("fishing content");
+        fishing.TrustState = TrustState.Flagged;
+        var hiking = NewFact("hiking content");
+        hiking.TrustState = TrustState.Flagged;
+        hiking.Domain = "hiking";
+        var repo = new FakeFactRepository(fishing, hiking);
+
+        var result = await ReviewQueueEndpoints.GetReviewQueue("hiking", 100, repo, CancellationToken.None);
+
+        var ok = Assert.IsType<Ok<List<Fact>>>(result);
+        Assert.Single(ok.Value!);
+        Assert.Equal(hiking.Id, ok.Value![0].Id);
+    }
+
+    [Fact]
+    public async Task GetReviewQueue_ClampsLimitToMaximum()
+    {
+        var repo = new FakeFactRepository();
+
+        await ReviewQueueEndpoints.GetReviewQueue(null, 5000, repo, CancellationToken.None);
+
+        Assert.Equal(500, repo.LastReviewQueueLimit);
+    }
+
+    // ---- GET/PUT /api/domains/{domain}/trust-policy ----
+
+    [Fact]
+    public async Task GetTrustPolicy_ReturnsNotFound_WhenUnconfigured()
+    {
+        var repo = new FakeDomainTrustPolicyRepository();
+
+        var result = await DomainTrustPolicyEndpoints.GetTrustPolicy("fishing", repo, CancellationToken.None);
+
+        Assert.IsType<NotFound>(result);
+    }
+
+    [Fact]
+    public async Task UpdateTrustPolicy_ThenGetTrustPolicy_RoundTrips()
+    {
+        var repo = new FakeDomainTrustPolicyRepository();
+        var request = new UpdateTrustPolicyRequest(
+            RequirePrimarySource: true,
+            MinCorroboration: 2,
+            AutoAcceptTiers: [SourceTier.Primary],
+            FlagForReviewTiers: [SourceTier.Unverified],
+            TemporalValidityRequired: true,
+            MinConfidenceScore: 0.7f);
+
+        var putResult = await DomainTrustPolicyEndpoints.UpdateTrustPolicy("fishing", request, repo, CancellationToken.None);
+        var getResult = await DomainTrustPolicyEndpoints.GetTrustPolicy("fishing", repo, CancellationToken.None);
+
+        var putOk = Assert.IsType<Ok<DomainTrustPolicy>>(putResult);
+        var getOk = Assert.IsType<Ok<DomainTrustPolicy>>(getResult);
+        Assert.Equal("fishing", putOk.Value!.Domain);
+        Assert.Equal(2, getOk.Value!.MinCorroboration);
+        Assert.Equal(0.7f, getOk.Value.MinConfidenceScore);
+        Assert.Contains(SourceTier.Unverified, getOk.Value.FlagForReviewTiers);
+    }
+
     // ---- helpers & fakes ----
 
     private static Fact NewFact(string content, float confidence = 1.0f) => new()
@@ -287,7 +370,18 @@ public class ApiEndpointTests
         public Task SetTrustStateAsync(Guid id, TrustState state, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetContradictionScanCandidatesAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
         public Task MarkContradictedAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<List<Fact>> GetPendingReviewAsync(string? domain, int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public int? LastReviewQueueLimit { get; private set; }
+
+        public Task<List<Fact>> GetPendingReviewAsync(string? domain, int limit, CancellationToken ct = default)
+        {
+            LastReviewQueueLimit = limit;
+            return Task.FromResult(Facts.Values
+                .Where(f => f.TrustState is TrustState.Flagged or TrustState.Contested
+                    && (domain is null || f.Domain == domain))
+                .OrderByDescending(f => f.CreatedAt)
+                .Take(limit)
+                .ToList());
+        }
         public Task<List<DomainStats>> GetDomainStatsAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<Fact?> GetByContentHashAsync(string contentHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<Fact?> GetByNormalizedHashAsync(string normalizedHash, string domain, CancellationToken ct = default) => throw new NotImplementedException();
@@ -327,5 +421,22 @@ public class ApiEndpointTests
         public Task<List<Source>> GetAllAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task DeactivateAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
         public Task DeleteAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+    }
+
+    private sealed class FakeDomainTrustPolicyRepository : IDomainTrustPolicyRepository
+    {
+        private readonly Dictionary<string, DomainTrustPolicy> _policies = new();
+
+        public Task<DomainTrustPolicy?> GetByDomainAsync(string domain, CancellationToken ct = default)
+            => Task.FromResult(_policies.GetValueOrDefault(domain));
+
+        public Task<List<DomainTrustPolicy>> GetAllAsync(CancellationToken ct = default)
+            => Task.FromResult(_policies.Values.ToList());
+
+        public Task UpsertAsync(DomainTrustPolicy policy, CancellationToken ct = default)
+        {
+            _policies[policy.Domain] = policy;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/Deke.Tests/BootstrapIngestionTests.cs
+++ b/tests/Deke.Tests/BootstrapIngestionTests.cs
@@ -133,8 +133,13 @@ public class BootstrapIngestionTests : IDisposable
         public Task<Fact?> GetByIdAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetByDomainAsync(string domain, int limit = 100, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetBySourceAsync(Guid sourceId, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<List<FactSearchResult>> SearchAsync(float[] embedding, string? domain, int limit = 10, float minSimilarity = 0.5f, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<FactSearchResult>> SearchAsync(float[] embedding, string? domain, int limit = 10, float minSimilarity = 0.5f, float? maxSimilarity = null, CancellationToken ct = default) => throw new NotImplementedException();
         public Task UpdateAsync(Fact fact, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingTrustEvaluationAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task SetTrustStateAsync(Guid id, TrustState state, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetContradictionScanCandidatesAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task MarkContradictedAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingReviewAsync(string? domain, int limit, CancellationToken ct = default) => throw new NotImplementedException();
         public Task MarkOutdatedAsync(Guid id, string reason, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<int> GetCountAsync(string domain, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetRecentAsync(string domain, int days, int limit = 100, CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/Deke.Tests/ContradictionDetectionServiceTests.cs
+++ b/tests/Deke.Tests/ContradictionDetectionServiceTests.cs
@@ -1,0 +1,114 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+using Deke.Infrastructure.Ingestion;
+using Deke.Tests.Fakes;
+using Deke.Worker.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Deke.Tests;
+
+public class ContradictionDetectionServiceTests
+{
+    private readonly InMemoryFactRepository _facts = new();
+    private readonly FakeFactRelationRepository _relations = new();
+    private readonly FakeLearningLogRepository _learningLog = new();
+
+    private ContradictionDetectionService BuildService(ContradictionDetectionConfig config)
+    {
+        var provider = new ServiceCollection()
+            .AddScoped<IFactRepository>(_ => _facts)
+            .AddScoped<IFactRelationRepository>(_ => _relations)
+            .AddScoped<ILearningLogRepository>(_ => _learningLog)
+            .BuildServiceProvider();
+
+        return new ContradictionDetectionService(
+            provider, NullLogger<ContradictionDetectionService>.Instance, Options.Create(config));
+    }
+
+    /// <summary>
+    /// Unit vector at the given angle in the first two dimensions (zero-padded
+    /// to 8). Cosine similarity between Embedding(a) and Embedding(b) is exactly
+    /// cos(a - b) degrees, so tests can target a precise similarity band.
+    /// </summary>
+    private static float[] Embedding(double angleDegrees)
+    {
+        var radians = angleDegrees * Math.PI / 180.0;
+        return [(float)Math.Cos(radians), (float)Math.Sin(radians), 0, 0, 0, 0, 0, 0];
+    }
+
+    [Fact]
+    public async Task RunCycleAsync_FactsInSimilarityBand_AreFlaggedAndLinked()
+    {
+        var factA = new Fact
+        {
+            Content = "content A",
+            Domain = "fishing",
+            TrustState = TrustState.Accepted,
+            Embedding = Embedding(0),
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-1)
+        };
+        var factB = new Fact
+        {
+            Content = "content B",
+            Domain = "fishing",
+            TrustState = TrustState.Accepted,
+            Embedding = Embedding(30), // cosine similarity to factA: cos(30 deg) = ~0.866
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        _facts.Seed(factA, factB);
+
+        // Band wide enough to catch these two near-but-not-duplicate embeddings.
+        var service = BuildService(new ContradictionDetectionConfig
+        {
+            BatchSize = 100,
+            MinSimilarity = 0.0f,
+            MaxSimilarity = 0.999999f
+        });
+        await service.RunCycleAsync(CancellationToken.None);
+
+        Assert.True(_facts.Get(factA.Id).ContradictionFlag);
+        Assert.True(_facts.Get(factB.Id).ContradictionFlag);
+        Assert.Equal(TrustState.Contested, _facts.Get(factA.Id).TrustState);
+        Assert.Equal(TrustState.Contested, _facts.Get(factB.Id).TrustState);
+        Assert.Contains(_relations.Records, r => r.RelationType == "contradicts"
+            && ((r.FromFactId == factA.Id && r.ToFactId == factB.Id) || (r.FromFactId == factB.Id && r.ToFactId == factA.Id)));
+    }
+
+    [Fact]
+    public async Task RunCycleAsync_SamePairTwice_DoesNotDuplicateTheRelation()
+    {
+        var factA = new Fact { Content = "content A", Domain = "fishing", TrustState = TrustState.Accepted, Embedding = Embedding(0) };
+        var factB = new Fact { Content = "content B", Domain = "fishing", TrustState = TrustState.Accepted, Embedding = Embedding(30) };
+        _facts.Seed(factA, factB);
+
+        var config = new ContradictionDetectionConfig { BatchSize = 100, MinSimilarity = 0.0f, MaxSimilarity = 0.999999f };
+        var service = BuildService(config);
+        await service.RunCycleAsync(CancellationToken.None);
+
+        // Reset the flag-driven exclusion so the same pair is re-scanned...
+        _facts.Get(factA.Id).ContradictionFlag = false;
+        _facts.Get(factB.Id).ContradictionFlag = false;
+        await service.RunCycleAsync(CancellationToken.None);
+
+        var relationCount = _relations.Records.Count(r => r.RelationType == "contradicts");
+        Assert.Equal(1, relationCount);
+    }
+
+    [Fact]
+    public async Task RunCycleAsync_RejectedFact_IsNotBumpedToContested()
+    {
+        // factA is Rejected, so it is not itself a scan candidate; factB is, and
+        // discovers factA as a similarity-band match while scanning.
+        var factA = new Fact { Content = "content A", Domain = "fishing", TrustState = TrustState.Rejected, Embedding = Embedding(0) };
+        var factB = new Fact { Content = "content B", Domain = "fishing", TrustState = TrustState.Accepted, Embedding = Embedding(30) };
+        _facts.Seed(factA, factB);
+
+        var service = BuildService(new ContradictionDetectionConfig { BatchSize = 100, MinSimilarity = 0.0f, MaxSimilarity = 0.999999f });
+        await service.RunCycleAsync(CancellationToken.None);
+
+        Assert.Equal(TrustState.Rejected, _facts.Get(factA.Id).TrustState);
+        Assert.True(_facts.Get(factA.Id).ContradictionFlag);
+    }
+}

--- a/tests/Deke.Tests/Fakes/FakeDomainTrustPolicyRepository.cs
+++ b/tests/Deke.Tests/Fakes/FakeDomainTrustPolicyRepository.cs
@@ -1,0 +1,23 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+
+namespace Deke.Tests.Fakes;
+
+public sealed class FakeDomainTrustPolicyRepository : IDomainTrustPolicyRepository
+{
+    private readonly Dictionary<string, DomainTrustPolicy> _policies = new();
+
+    public void Seed(DomainTrustPolicy policy) => _policies[policy.Domain] = policy;
+
+    public Task<DomainTrustPolicy?> GetByDomainAsync(string domain, CancellationToken ct = default)
+        => Task.FromResult(_policies.GetValueOrDefault(domain));
+
+    public Task<List<DomainTrustPolicy>> GetAllAsync(CancellationToken ct = default)
+        => Task.FromResult(_policies.Values.ToList());
+
+    public Task UpsertAsync(DomainTrustPolicy policy, CancellationToken ct = default)
+    {
+        _policies[policy.Domain] = policy;
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Deke.Tests/Fakes/FakeFactRelationRepository.cs
+++ b/tests/Deke.Tests/Fakes/FakeFactRelationRepository.cs
@@ -1,0 +1,31 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+
+namespace Deke.Tests.Fakes;
+
+public sealed class FakeFactRelationRepository : IFactRelationRepository
+{
+    public List<FactRelation> Records { get; } = [];
+
+    public Task<List<FactRelation>> GetByFactIdAsync(Guid factId, CancellationToken ct = default) =>
+        Task.FromResult(Records.Where(r => r.FromFactId == factId || r.ToFactId == factId).ToList());
+
+    public Task<Guid> AddAsync(FactRelation relation, CancellationToken ct = default)
+    {
+        Records.Add(relation);
+        return Task.FromResult(relation.Id);
+    }
+
+    public Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        Records.RemoveAll(r => r.Id == id);
+        return Task.CompletedTask;
+    }
+
+    public Task<List<FactRelation>> GetByRelationTypeAsync(string relationType, string domain, CancellationToken ct = default) =>
+        Task.FromResult(Records.Where(r => r.RelationType == relationType).ToList());
+
+    public Task<bool> ExistsAsync(Guid fromFactId, Guid toFactId, string relationType, CancellationToken ct = default) =>
+        Task.FromResult(Records.Any(r =>
+            r.FromFactId == fromFactId && r.ToFactId == toFactId && r.RelationType == relationType));
+}

--- a/tests/Deke.Tests/Fakes/FakeSourceRepository.cs
+++ b/tests/Deke.Tests/Fakes/FakeSourceRepository.cs
@@ -1,0 +1,32 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+
+namespace Deke.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="ISourceRepository"/> for worker tests that only need
+/// source-tier lookups; unrelated members throw.
+/// </summary>
+public sealed class FakeSourceRepository : ISourceRepository
+{
+    private readonly Dictionary<Guid, Source> _sources = new();
+
+    public void Seed(params Source[] sources)
+    {
+        foreach (var source in sources)
+            _sources[source.Id] = source;
+    }
+
+    public Task<Source?> GetByIdAsync(Guid id, CancellationToken ct = default)
+        => Task.FromResult(_sources.GetValueOrDefault(id));
+
+    public Task<Source?> GetByUrlAsync(string url, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<List<Source>> GetByDomainAsync(string domain, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<List<Source>> GetActiveAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<List<Source>> GetDueForCheckAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<Guid> AddAsync(Source source, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task UpdateAsync(Source source, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<List<Source>> GetAllAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    public Task DeactivateAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task DeleteAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+}

--- a/tests/Deke.Tests/Fakes/InMemoryFactRepository.cs
+++ b/tests/Deke.Tests/Fakes/InMemoryFactRepository.cs
@@ -82,12 +82,13 @@ public sealed class InMemoryFactRepository : IFactRepository
             .OrderByDescending(f => f.CreatedAt).Take(limit).ToList());
 
     public Task<List<FactSearchResult>> SearchAsync(
-        float[] embedding, string? domain, int limit = 10, float minSimilarity = 0.5f, CancellationToken ct = default)
+        float[] embedding, string? domain, int limit = 10, float minSimilarity = 0.5f,
+        float? maxSimilarity = null, CancellationToken ct = default)
     {
         var results = _store.Values
             .Where(f => f.Embedding is { Length: > 0 } && (domain is null || f.Domain == domain))
             .Select(f => (Fact: f, Sim: Cosine(embedding, f.Embedding!)))
-            .Where(x => x.Sim > minSimilarity)
+            .Where(x => x.Sim > minSimilarity && (maxSimilarity is null || x.Sim <= maxSimilarity))
             .OrderByDescending(x => x.Sim)
             .Take(limit)
             .Select(x => new FactSearchResult
@@ -122,6 +123,43 @@ public sealed class InMemoryFactRepository : IFactRepository
         }
         return na == 0 || nb == 0 ? 0 : dot / (MathF.Sqrt(na) * MathF.Sqrt(nb));
     }
+
+    public Task<List<Fact>> GetPendingTrustEvaluationAsync(int limit, CancellationToken ct = default) =>
+        Task.FromResult(_store.Values
+            .Where(f => f.TrustState == TrustState.Unscored && f.DuplicateOf is null && !f.IsOutdated)
+            .OrderBy(f => f.CreatedAt).Take(limit).ToList());
+
+    public Task SetTrustStateAsync(Guid id, TrustState state, CancellationToken ct = default)
+    {
+        if (_store.TryGetValue(id, out var f))
+            f.TrustState = state;
+        return Task.CompletedTask;
+    }
+
+    public Task<List<Fact>> GetContradictionScanCandidatesAsync(int limit, CancellationToken ct = default) =>
+        Task.FromResult(_store.Values
+            .Where(f => f.TrustState is TrustState.Accepted or TrustState.Flagged
+                && !f.ContradictionFlag && f.Embedding is { Length: > 0 }
+                && f.DuplicateOf is null && !f.IsOutdated)
+            .OrderBy(f => f.CreatedAt).Take(limit).ToList());
+
+    public Task MarkContradictedAsync(Guid id, CancellationToken ct = default)
+    {
+        if (_store.TryGetValue(id, out var f))
+        {
+            f.ContradictionFlag = true;
+            if (f.TrustState != TrustState.Rejected)
+                f.TrustState = TrustState.Contested;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task<List<Fact>> GetPendingReviewAsync(string? domain, int limit, CancellationToken ct = default) =>
+        Task.FromResult(_store.Values
+            .Where(f => f.TrustState is TrustState.Flagged or TrustState.Contested
+                && (domain is null || f.Domain == domain)
+                && f.DuplicateOf is null && !f.IsOutdated)
+            .OrderByDescending(f => f.CreatedAt).Take(limit).ToList());
 
     public Task<List<Fact>> GetBySourceAsync(Guid sourceId, CancellationToken ct = default) => throw new NotImplementedException();
     public Task MarkOutdatedAsync(Guid id, string reason, CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/Deke.Tests/InteractionLoggingTests.cs
+++ b/tests/Deke.Tests/InteractionLoggingTests.cs
@@ -81,13 +81,19 @@ public class InteractionLoggingTests
     private sealed class FakeFactRepository(List<FactSearchResult> results) : IFactRepository
     {
         public Task<List<FactSearchResult>> SearchAsync(
-            float[] embedding, string? domain, int limit = 10, float minSimilarity = 0.5f, CancellationToken ct = default)
+            float[] embedding, string? domain, int limit = 10, float minSimilarity = 0.5f,
+            float? maxSimilarity = null, CancellationToken ct = default)
             => Task.FromResult(results);
 
         public Task<Fact?> GetByIdAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetByDomainAsync(string domain, int limit = 100, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<Fact>> GetBySourceAsync(Guid sourceId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<Guid> AddAsync(Fact fact, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingTrustEvaluationAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task SetTrustStateAsync(Guid id, TrustState state, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetContradictionScanCandidatesAsync(int limit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task MarkContradictedAsync(Guid id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<Fact>> GetPendingReviewAsync(string? domain, int limit, CancellationToken ct = default) => throw new NotImplementedException();
         public Task UpdateAsync(Fact fact, CancellationToken ct = default) => throw new NotImplementedException();
         public Task MarkOutdatedAsync(Guid id, string reason, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<int> GetCountAsync(string domain, CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/Deke.Tests/TrustEvaluatorTests.cs
+++ b/tests/Deke.Tests/TrustEvaluatorTests.cs
@@ -1,0 +1,144 @@
+﻿using Deke.Core.Models;
+using Deke.Infrastructure.Trust;
+
+namespace Deke.Tests;
+
+public class TrustEvaluatorTests
+{
+    private readonly TrustEvaluator _evaluator = new();
+
+    private static Fact MakeFact(
+        float confidence = 1.0f,
+        int corroborationCount = 0,
+        DateTimeOffset? validFrom = null) => new()
+        {
+            Content = "test content",
+            Domain = "fishing",
+            Confidence = confidence,
+            CorroborationCount = corroborationCount,
+            ValidFrom = validFrom
+        };
+
+    private static DomainTrustPolicy MakePolicy(
+        bool requirePrimarySource = false,
+        int minCorroboration = 0,
+        List<SourceTier>? flagForReviewTiers = null,
+        bool temporalValidityRequired = false,
+        float minConfidenceScore = 0f) => new()
+        {
+            Domain = "fishing",
+            RequirePrimarySource = requirePrimarySource,
+            MinCorroboration = minCorroboration,
+            FlagForReviewTiers = flagForReviewTiers ?? [],
+            TemporalValidityRequired = temporalValidityRequired,
+            MinConfidenceScore = minConfidenceScore
+        };
+
+    [Fact]
+    public void Evaluate_NoPolicy_ReturnsAccepted()
+    {
+        var result = _evaluator.Evaluate(MakeFact(), sourceTier: null, policy: null);
+
+        Assert.Equal(TrustState.Accepted, result);
+    }
+
+    [Fact]
+    public void Evaluate_RequiresPrimarySource_NonPrimaryTier_ReturnsFlagged()
+    {
+        var policy = MakePolicy(requirePrimarySource: true);
+
+        var result = _evaluator.Evaluate(MakeFact(), SourceTier.Secondary, policy);
+
+        Assert.Equal(TrustState.Flagged, result);
+    }
+
+    [Fact]
+    public void Evaluate_RequiresPrimarySource_PrimaryTier_ReturnsAccepted()
+    {
+        var policy = MakePolicy(requirePrimarySource: true);
+
+        var result = _evaluator.Evaluate(MakeFact(), SourceTier.Primary, policy);
+
+        Assert.Equal(TrustState.Accepted, result);
+    }
+
+    [Fact]
+    public void Evaluate_TemporalValidityRequired_MissingValidFrom_ReturnsFlagged()
+    {
+        var policy = MakePolicy(temporalValidityRequired: true);
+
+        var result = _evaluator.Evaluate(MakeFact(validFrom: null), sourceTier: null, policy);
+
+        Assert.Equal(TrustState.Flagged, result);
+    }
+
+    [Fact]
+    public void Evaluate_TemporalValidityRequired_HasValidFrom_ReturnsAccepted()
+    {
+        var policy = MakePolicy(temporalValidityRequired: true);
+
+        var result = _evaluator.Evaluate(MakeFact(validFrom: DateTimeOffset.UtcNow), sourceTier: null, policy);
+
+        Assert.Equal(TrustState.Accepted, result);
+    }
+
+    [Fact]
+    public void Evaluate_ConfidenceBelowMinimum_ReturnsFlagged()
+    {
+        var policy = MakePolicy(minConfidenceScore: 0.8f);
+
+        var result = _evaluator.Evaluate(MakeFact(confidence: 0.5f), sourceTier: null, policy);
+
+        Assert.Equal(TrustState.Flagged, result);
+    }
+
+    [Fact]
+    public void Evaluate_ConfidenceAtOrAboveMinimum_ReturnsAccepted()
+    {
+        var policy = MakePolicy(minConfidenceScore: 0.8f);
+
+        var result = _evaluator.Evaluate(MakeFact(confidence: 0.8f), sourceTier: null, policy);
+
+        Assert.Equal(TrustState.Accepted, result);
+    }
+
+    [Fact]
+    public void Evaluate_BelowMinCorroboration_ReturnsFlagged()
+    {
+        var policy = MakePolicy(minCorroboration: 2);
+
+        var result = _evaluator.Evaluate(MakeFact(corroborationCount: 1), sourceTier: null, policy);
+
+        Assert.Equal(TrustState.Flagged, result);
+    }
+
+    [Fact]
+    public void Evaluate_MeetsMinCorroboration_ReturnsAccepted()
+    {
+        var policy = MakePolicy(minCorroboration: 2);
+
+        var result = _evaluator.Evaluate(MakeFact(corroborationCount: 2), sourceTier: null, policy);
+
+        Assert.Equal(TrustState.Accepted, result);
+    }
+
+    [Fact]
+    public void Evaluate_SourceTierInFlagForReviewList_ReturnsFlagged()
+    {
+        var policy = MakePolicy(flagForReviewTiers: [SourceTier.Unverified]);
+
+        var result = _evaluator.Evaluate(MakeFact(), SourceTier.Unverified, policy);
+
+        Assert.Equal(TrustState.Flagged, result);
+    }
+
+    [Fact]
+    public void Evaluate_SourceTierNotListed_AllGatesPassed_ReturnsAccepted()
+    {
+        var policy = MakePolicy(flagForReviewTiers: [SourceTier.Unverified]);
+
+        var result = _evaluator.Evaluate(MakeFact(), SourceTier.Aggregated, policy);
+
+        Assert.Equal(TrustState.Accepted, result);
+    }
+}

--- a/tests/Deke.Tests/TrustStateEvaluationServiceTests.cs
+++ b/tests/Deke.Tests/TrustStateEvaluationServiceTests.cs
@@ -1,0 +1,76 @@
+﻿using Deke.Core.Interfaces;
+using Deke.Core.Models;
+using Deke.Infrastructure.Ingestion;
+using Deke.Infrastructure.Trust;
+using Deke.Tests.Fakes;
+using Deke.Worker.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Deke.Tests;
+
+public class TrustStateEvaluationServiceTests
+{
+    private readonly InMemoryFactRepository _facts = new();
+    private readonly FakeSourceRepository _sources = new();
+    private readonly FakeDomainTrustPolicyRepository _policies = new();
+    private readonly FakeLearningLogRepository _learningLog = new();
+
+    private TrustStateEvaluationService BuildService(TrustEvaluationConfig config)
+    {
+        var provider = new ServiceCollection()
+            .AddScoped<IFactRepository>(_ => _facts)
+            .AddScoped<ISourceRepository>(_ => _sources)
+            .AddScoped<IDomainTrustPolicyRepository>(_ => _policies)
+            .AddScoped<ILearningLogRepository>(_ => _learningLog)
+            .AddScoped<ITrustEvaluator, TrustEvaluator>()
+            .BuildServiceProvider();
+
+        return new TrustStateEvaluationService(
+            provider, NullLogger<TrustStateEvaluationService>.Instance, Options.Create(config));
+    }
+
+    [Fact]
+    public async Task RunCycleAsync_NoPolicyConfigured_TransitionsToAccepted()
+    {
+        var fact = new Fact { Content = "content", Domain = "fishing" };
+        _facts.Seed(fact);
+
+        var service = BuildService(new TrustEvaluationConfig { BatchSize = 100 });
+        await service.RunCycleAsync(CancellationToken.None);
+
+        Assert.Equal(TrustState.Accepted, _facts.Get(fact.Id).TrustState);
+    }
+
+    [Fact]
+    public async Task RunCycleAsync_TierInFlagForReviewList_TransitionsToFlagged()
+    {
+        var source = new Source { Url = "https://example.com/feed.rss", Domain = "fishing", SourceTier = SourceTier.Unverified };
+        var fact = new Fact { Content = "content", Domain = "fishing", SourceId = source.Id };
+        _facts.Seed(fact);
+        _sources.Seed(source);
+        _policies.Seed(new DomainTrustPolicy
+        {
+            Domain = "fishing",
+            FlagForReviewTiers = [SourceTier.Unverified]
+        });
+
+        var service = BuildService(new TrustEvaluationConfig { BatchSize = 100 });
+        await service.RunCycleAsync(CancellationToken.None);
+
+        Assert.Equal(TrustState.Flagged, _facts.Get(fact.Id).TrustState);
+    }
+
+    [Fact]
+    public async Task RunCycleAsync_AlreadyScoredFacts_AreNotReEvaluated()
+    {
+        var fact = new Fact { Content = "content", Domain = "fishing", TrustState = TrustState.Flagged };
+        _facts.Seed(fact);
+
+        var service = BuildService(new TrustEvaluationConfig { BatchSize = 100 });
+        await service.RunCycleAsync(CancellationToken.None);
+
+        Assert.Equal(TrustState.Flagged, _facts.Get(fact.Id).TrustState);
+    }
+}


### PR DESCRIPTION
## Summary
- Activates the P1-1 trust schema into working behavior: `ITrustEvaluator` classifies `Unscored` facts to `Accepted`/`Flagged` per `domain_trust_policy` (fails open when a domain has no policy configured).
- Two new Worker background jobs, mirroring R2's L4/L5 split: `TrustStateEvaluationService` (policy-driven classification) and `ContradictionDetectionService` (basic, non-version-aware embedding-similarity heuristic; bumps `trust_state` to `Contested` and records a `"contradicts"` `FactRelation`, never resurrecting an already-`Rejected` fact).
- `GET /api/review-queue` and `GET`/`PUT /api/domains/{domain}/trust-policy` — the latter closes a P1-1 gap where the trust-policy repository shipped with zero endpoints wired to it.
- OI-07 (version-aware contradiction resolution) and OI-08 (fact retirement/archival) reviewed as scheduled and dispositioned as deferred via [ADR-0012](docs/adr/ADR-0012-oi-07-version-aware-contradiction-deferred.md) and [ADR-0013](docs/adr/ADR-0013-oi-08-fact-retirement-archival-deferred.md).

## Acceptance Criteria
- [x] `GET /api/review-queue` live, selected per `domain_trust_policy`
- [x] Trust-policy `GET`/`PUT` endpoints implemented and wired
- [x] Temporal-validity handling (missing-`valid_from` flagging; `valid_until` already covered by the pre-existing `ITrustScoringService`)
- [x] Basic contradiction detection sets `contradiction_flag`; version-awareness deferred via ADR-0012
- [x] OI-08 fact-retirement dispositioned via ADR-0013
- [x] `trust_state` transitions driven by the pipeline (`Unscored → Accepted/Flagged/Contested`)
- [x] xUnit coverage for review-queue, temporal validity, contradiction flagging, trust-policy endpoints
- [x] `dotnet build`/`test` green
- [x] `GET /api/review-queue` live-verified against `deke-postgres`
- [x] OI-07/OI-08 recorded as dispositioned in `decisions.md` Review Schedule

## Changes
33 files changed (+1275/-15): new `ITrustEvaluator` (Core+Infrastructure), 5 new `IFactRepository` methods + one new optional `SearchAsync` param, 2 new API endpoint files, 2 new Worker background services, 1 new partial index (`idx_facts_trust_state`), 2 new ADRs, decisions.md/specification.md/ROADMAP.md updates, 22 new tests (115/115 total passing).

## Testing
- `dotnet build` — 0 errors
- `dotnet test` — 115/115 passing
- `dotnet format --verify-no-changes` — clean
- Live-verified against the running `deke-postgres` container: index applied live, review-queue domain-filtering confirmed against a manually-flagged fact, trust-policy PUT/GET round-trip confirmed with `X-Api-Key` auth enforcement (401 without, 200 with).

## Notes
- Found and fixed two bugs surfaced during implementation, not anticipated by the plan:
  - `SearchAsync`'s new optional param broke two positional callers (`AdvisoryPipeline.cs`, `FederatedSearchService.cs`) — fixed with named arguments.
  - `SourceTier` had no JSON string-enum converter (same class of bug as HYG-1's already-flagged `SourceType` issue) — caught live when the trust-policy PUT 400'd on `["Primary"]`. Fixed narrowly (attribute on the enum itself) rather than a global API JSON option change, so it doesn't affect other endpoints' response shapes or preempt HYG-1's own open `SourceType` decision.
- Follow-up work identified, not in this PR's scope: `docs/PROJECT-MAP.md`'s `Deke.Worker` section doesn't yet list the two new services (consistent with R2 also skipping this file); a `fishing`-domain `domain_trust_policy` row was created during live verification and left in place (plausible real config, not test junk) — flagged for the repo owner to adjust or clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)